### PR TITLE
Add ProxyRequestTimeout option for long-running backend requests

### DIFF
--- a/configure/configure_test.go
+++ b/configure/configure_test.go
@@ -27,7 +27,7 @@ func (s *ConfSuite) SetUpTest(c *C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	s.conf = NewConfigurator(proxy)
+	s.conf = NewConfigurator(proxy, &ConfiguratorOptions{})
 }
 
 var _ = Suite(&ConfSuite{})


### PR DESCRIPTION
Vulcand was not setting any timeouts in the httploc package inside the vulcan library and so requests which might take more than 10s to serve from the backends were timing out.

This PR adds an option to set the timeout in proxy requests, and sets vulcand's writeTimeout to that same timeout if it exists.
