### PR TITLE
Fix missing assignment to `err` variable

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -248,7 +248,7 @@ func (c *Client) RoundTrip(fn RoundTripFn) ([]byte, error) {
 	}
 	if response.StatusCode != http.StatusOK {
 		var status *StatusResponse
-		if json.Unmarshal(responseBody, &status); err != nil {
+		if err := json.Unmarshal(responseBody, &status); err != nil {
 			return nil, fmt.Errorf("Failed to decode response '%s', error: %", responseBody, err)
 		}
 		if response.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
Fixes a nil pointer dereference in the case that json.Unmarshal fails.
