### PR TITLE
Implement lazy recursive reads from Etcd.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ install: clean
 run: install
 	vulcand -etcd=${ETCD_NODE1} -etcd=${ETCD_NODE2} -etcd=${ETCD_NODE3} -etcdKey=/vulcand -sealKey=${SEAL_KEY} -statsdAddr=localhost:8125 -statsdPrefix=vulcan -logSeverity=INFO
 
+run-http-only: install
+	vulcand -etcd=${ETCD_NODE1} -etcd=${ETCD_NODE2} -etcd=${ETCD_NODE3} -etcdKey=/vulcand -statsdAddr=localhost:8125 -statsdPrefix=vulcan -logSeverity=INFO
+
 run-test-mode: install
 	vulcand -etcd=${ETCD_NODE1} -etcd=${ETCD_NODE2} -etcd=${ETCD_NODE3} -etcdKey=${PREFIX} -sealKey=${SEAL_KEY} -logSeverity=INFO
 

--- a/backend/etcdbackend/client.go
+++ b/backend/etcdbackend/client.go
@@ -1,0 +1,147 @@
+package etcdbackend
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mailgun/vulcand/Godeps/_workspace/src/github.com/mailgun/go-etcd/etcd"
+	"github.com/mailgun/vulcand/backend"
+	"github.com/mailgun/vulcand/secret"
+)
+
+// lazyClient caches the keys that have been read and uses recursive queries
+// what helps to reduce the amount of read requests to the Etcd backend.
+// It is recommended to use lazyClient only in the context of the single call
+// to the public etcdbackend interface to avoid dealing with cache invalidation issues.
+type lazyClient struct {
+	nodes map[string]*etcd.Node
+	b     *secret.Box
+	c     *etcd.Client
+}
+
+func newLazyClient(c *etcd.Client, b *secret.Box) (*lazyClient, error) {
+	client := &lazyClient{
+		nodes: make(map[string]*etcd.Node),
+		b:     b,
+		c:     c,
+	}
+	return client, nil
+}
+
+// getNode will retreive the value from the backend and cache it for subsequent reads.
+func (c *lazyClient) getNode(key string) (*etcd.Node, error) {
+	for k, n := range c.nodes {
+		if strings.HasPrefix(key, k) {
+			return c.findNode(key, n)
+		}
+	}
+	response, err := c.c.Get(key, true, true)
+	if err != nil {
+		return nil, convertErr(err)
+	}
+	c.nodes[key] = response.Node
+	return c.findNode(key, response.Node)
+}
+
+// findNode searches the root node for the child with matching key.
+func (c *lazyClient) findNode(key string, node *etcd.Node) (*etcd.Node, error) {
+	if node == nil {
+		return nil, &backend.NotFoundError{Message: fmt.Sprintf("key '%s' not found", key)}
+	}
+	if key == node.Key {
+		return node, nil
+	}
+	if !isDir(node) {
+		return nil, &backend.NotFoundError{Message: fmt.Sprintf("key '%s' not found", key)}
+	}
+
+	for _, child := range node.Nodes {
+		n, err := c.findNode(key, child)
+		if err == nil {
+			return n, nil
+		}
+	}
+	return nil, &backend.NotFoundError{Message: fmt.Sprintf("key '%s' not found", key)}
+}
+
+func (c *lazyClient) getVals(key string) ([]Pair, error) {
+	var out []Pair
+	n, err := c.getNode(key)
+	if err != nil {
+		if isNotFoundError(err) {
+			return out, nil
+		}
+		return nil, err
+	}
+	if !isDir(n) {
+		return out, nil
+	}
+	for _, srvNode := range n.Nodes {
+		if !isDir(srvNode) {
+			out = append(out, Pair{srvNode.Key, srvNode.Value})
+		}
+	}
+	return out, nil
+}
+
+func (c *lazyClient) getVal(key string) (string, error) {
+	n, err := c.getNode(key)
+	if err != nil {
+		return "", err
+	}
+	if isDir(n) {
+		return "", &backend.NotFoundError{Message: fmt.Sprintf("expected value, got dir for key '%s'", key)}
+	}
+	return n.Value, nil
+}
+
+func (c *lazyClient) getSealedVal(key string) ([]byte, error) {
+	bytes, err := c.getVal(key)
+	if err != nil {
+		return nil, err
+	}
+	if c.b == nil {
+		return nil, fmt.Errorf("this backend does not support encryption bla: %s %s", bytes, err)
+	}
+	sv, err := secret.SealedValueFromJSON([]byte(bytes))
+	if err != nil {
+		return nil, err
+	}
+	return c.b.Open(sv)
+}
+
+func (c *lazyClient) getJSONVal(key string, in interface{}) error {
+	val, err := c.getVal(key)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(val), in)
+}
+
+func (c *lazyClient) checkKeyExists(key string) error {
+	_, err := c.getNode(key)
+	return err
+}
+
+func (c *lazyClient) getDirs(key string) ([]string, error) {
+	var out []string
+	n, err := c.getNode(key)
+	if err != nil {
+		if isNotFoundError(err) {
+			return out, nil
+		}
+		return nil, err
+	}
+
+	if !isDir(n) {
+		return out, nil
+	}
+
+	for _, srvNode := range n.Nodes {
+		if isDir(srvNode) {
+			out = append(out, srvNode.Key)
+		}
+	}
+	return out, nil
+}

--- a/backend/etcdbackend/etcdbackend.go
+++ b/backend/etcdbackend/etcdbackend.go
@@ -77,7 +77,7 @@ func (s *EtcdBackend) GetRegistry() *plugin.Registry {
 }
 
 func (s *EtcdBackend) GetHosts() ([]*backend.Host, error) {
-	return s.readHosts(true)
+	return s.readHosts(nil, true)
 }
 
 func (s *EtcdBackend) UpdateHostKeyPair(hostname string, keyPair *backend.KeyPair) (*backend.Host, error) {
@@ -151,7 +151,7 @@ func (s *EtcdBackend) DeleteHostListener(hostname string, listenerId string) err
 }
 
 func (s *EtcdBackend) GetHost(hostname string) (*backend.Host, error) {
-	return s.readHost(hostname, true)
+	return s.readHost(nil, hostname, true)
 }
 
 func (s *EtcdBackend) setHostKeyPair(hostname string, keyPair *backend.KeyPair) error {
@@ -162,11 +162,12 @@ func (s *EtcdBackend) setHostKeyPair(hostname string, keyPair *backend.KeyPair) 
 	return s.setSealedVal(s.path("hosts", hostname, "keypair"), bytes)
 }
 
-func (s *EtcdBackend) readHostKeyPair(hostname string) (*backend.KeyPair, error) {
-	if s.options.Box == nil {
-		return nil, nil
+func (s *EtcdBackend) readHostKeyPair(c *lazyClient, hostname string) (*backend.KeyPair, error) {
+	keyPairKey := s.path("hosts", hostname, "keypair")
+	if err := s.initClient(keyPairKey, &c); err != nil {
+		return nil, err
 	}
-	bytes, err := s.getSealedVal(s.path("hosts", hostname, "keypair"))
+	bytes, err := c.getSealedVal(keyPairKey)
 	if err != nil {
 		return nil, err
 	}
@@ -177,15 +178,36 @@ func (s *EtcdBackend) readHostKeyPair(hostname string) (*backend.KeyPair, error)
 	return keyPair, nil
 }
 
-func (s *EtcdBackend) readHost(hostname string, deep bool) (*backend.Host, error) {
+func (s *EtcdBackend) initClient(key string, c **lazyClient) error {
+	if *c == nil {
+		client, err := newLazyClient(s.client, s.options.Box)
+		if err != nil {
+			return err
+		}
+		*c = client
+	}
+
+	// Retrieve the value by key to cache it.
+	if _, err := c.getNode(key); !isNotFoundError(err) {
+		return err
+	}
+	return nil
+}
+
+func (s *EtcdBackend) readHost(c *lazyClient, hostname string, deep bool) (*backend.Host, error) {
 
 	hostKey := s.path("hosts", hostname)
-	if err := s.checkKeyExists(hostKey); err != nil {
+
+	if err := s.initClient(hostKey, &c); err != nil {
+		return nil, err
+	}
+
+	if err := c.checkKeyExists(hostKey); err != nil {
 		return nil, err
 	}
 
 	var options *backend.HostOptions
-	err := s.getJSONVal(join(hostKey, "options"), &options)
+	err := c.getJSONVal(join(hostKey, "options"), &options)
 	if err != nil {
 		if isNotFoundError(err) {
 			options = &backend.HostOptions{}
@@ -194,9 +216,8 @@ func (s *EtcdBackend) readHost(hostname string, deep bool) (*backend.Host, error
 		}
 	}
 
-	keyPair, err := s.readHostKeyPair(hostname)
+	keyPair, err := s.readHostKeyPair(c, hostname)
 	if err != nil && !isNotFoundError(err) {
-
 		return nil, err
 	}
 
@@ -208,7 +229,7 @@ func (s *EtcdBackend) readHost(hostname string, deep bool) (*backend.Host, error
 		Options:   *options,
 	}
 
-	listeners, err := s.getVals(hostKey, "listeners")
+	listeners, err := c.getVals(join(hostKey, "listeners"))
 	if err != nil {
 		return nil, err
 	}
@@ -221,16 +242,15 @@ func (s *EtcdBackend) readHost(hostname string, deep bool) (*backend.Host, error
 		l.Id = suffix(p.Key)
 		host.Listeners = append(host.Listeners, l)
 	}
-
 	if !deep {
 		return host, nil
 	}
-	locations, err := s.getDirs(hostKey, "locations")
+	locations, err := c.getDirs(join(hostKey, "locations"))
 	if err != nil {
 		return nil, err
 	}
 	for _, key := range locations {
-		location, err := s.GetLocation(hostname, suffix(key))
+		location, err := s.readLocation(c, hostname, suffix(key))
 		if err != nil {
 			return nil, err
 		}
@@ -249,7 +269,7 @@ func (s *EtcdBackend) AddLocation(l *backend.Location) (*backend.Location, error
 	}
 
 	// Check if the host of the location exists
-	if _, err := s.readHost(l.Hostname, false); err != nil {
+	if _, err := s.readHost(nil, l.Hostname, false); err != nil {
 		return nil, err
 	}
 
@@ -278,29 +298,37 @@ func (s *EtcdBackend) AddLocation(l *backend.Location) (*backend.Location, error
 	return l, nil
 }
 
-func (s *EtcdBackend) ExpectLocation(hostname, locationId string) error {
+func (s *EtcdBackend) expectLocation(hostname, locationId string) error {
 	return s.checkKeyExists(s.path("hosts", hostname, "locations", locationId))
 }
 
 func (s *EtcdBackend) GetLocation(hostname, locationId string) (*backend.Location, error) {
+	return s.readLocation(nil, hostname, locationId)
+}
+
+func (s *EtcdBackend) readLocation(c *lazyClient, hostname, locationId string) (*backend.Location, error) {
 	locationKey := s.path("hosts", hostname, "locations", locationId)
 
-	if err := s.checkKeyExists(locationKey); err != nil {
+	if err := s.initClient(locationKey, &c); err != nil {
 		return nil, err
 	}
 
-	path, err := s.getVal(join(locationKey, "path"))
+	if err := c.checkKeyExists(locationKey); err != nil {
+		return nil, err
+	}
+
+	path, err := c.getVal(join(locationKey, "path"))
 	if err != nil {
 		return nil, err
 	}
 
-	upstreamKey, err := s.getVal(join(locationKey, "upstream"))
+	upstreamKey, err := c.getVal(join(locationKey, "upstream"))
 	if err != nil {
 		return nil, err
 	}
 
 	var options *backend.LocationOptions
-	err = s.getJSONVal(join(locationKey, "options"), &options)
+	err = c.getJSONVal(join(locationKey, "options"), &options)
 	if err != nil {
 		if isNotFoundError(err) {
 			options = &backend.LocationOptions{}
@@ -316,17 +344,17 @@ func (s *EtcdBackend) GetLocation(hostname, locationId string) (*backend.Locatio
 		Middlewares: []*backend.MiddlewareInstance{},
 		Options:     *options,
 	}
-	upstream, err := s.GetUpstream(upstreamKey)
+	upstream, err := s.readUpstream(c, upstreamKey)
 	if err != nil {
 		return nil, err
 	}
 	for _, spec := range s.registry.GetSpecs() {
-		values, err := s.getVals(locationKey, "middlewares", spec.Type)
+		values, err := c.getVals(join(locationKey, "middlewares", spec.Type))
 		if err != nil {
 			return nil, err
 		}
 		for _, cl := range values {
-			m, err := s.GetLocationMiddleware(hostname, locationId, spec.Type, suffix(cl.Key))
+			m, err := s.readLocationMiddleware(c, hostname, locationId, spec.Type, suffix(cl.Key))
 			if err != nil {
 				log.Errorf("failed to read middleware %s(%s), error: %s", spec.Type, cl.Key, err)
 			} else {
@@ -379,9 +407,17 @@ func (s *EtcdBackend) AddUpstream(u *backend.Upstream) (*backend.Upstream, error
 }
 
 func (s *EtcdBackend) GetUpstream(upstreamId string) (*backend.Upstream, error) {
+	return s.readUpstream(nil, upstreamId)
+}
+
+func (s *EtcdBackend) readUpstream(c *lazyClient, upstreamId string) (*backend.Upstream, error) {
 	upstreamKey := s.path("upstreams", upstreamId)
 
-	if err := s.checkKeyExists(upstreamKey); err != nil {
+	if err := s.initClient(s.path("upstreams"), &c); err != nil {
+		return nil, err
+	}
+
+	if err := c.checkKeyExists(upstreamKey); err != nil {
 		return nil, err
 	}
 
@@ -390,7 +426,7 @@ func (s *EtcdBackend) GetUpstream(upstreamId string) (*backend.Upstream, error) 
 		Endpoints: []*backend.Endpoint{},
 	}
 
-	endpointPairs, err := s.getVals(join(upstreamKey, "endpoints"))
+	endpointPairs, err := c.getVals(join(upstreamKey, "endpoints"))
 	if err != nil {
 		return nil, err
 	}
@@ -410,13 +446,18 @@ func (s *EtcdBackend) GetUpstream(upstreamId string) (*backend.Upstream, error) 
 }
 
 func (s *EtcdBackend) GetUpstreams() ([]*backend.Upstream, error) {
+	upstreamsKey := join(s.etcdKey, "upstreams")
+	var c *lazyClient
+	if err := s.initClient(upstreamsKey, &c); err != nil {
+		return nil, err
+	}
 	upstreams := []*backend.Upstream{}
-	ups, err := s.getDirs(s.etcdKey, "upstreams")
+	ups, err := c.getDirs(upstreamsKey)
 	if err != nil {
 		return nil, err
 	}
 	for _, upstreamKey := range ups {
-		upstream, err := s.GetUpstream(suffix(upstreamKey))
+		upstream, err := s.readUpstream(c, suffix(upstreamKey))
 		if err != nil {
 			return nil, err
 		}
@@ -453,11 +494,18 @@ func (s *EtcdBackend) AddEndpoint(e *backend.Endpoint) (*backend.Endpoint, error
 }
 
 func (s *EtcdBackend) GetEndpoint(upstreamId, id string) (*backend.Endpoint, error) {
-	if _, err := s.GetUpstream(upstreamId); err != nil {
+	upstreamKey := s.path("upstreams", upstreamId)
+
+	var c *lazyClient
+	if err := s.initClient(upstreamKey, &c); err != nil {
 		return nil, err
 	}
 
-	url, err := s.getVal(s.path("upstreams", upstreamId, "endpoints", id))
+	if _, err := s.readUpstream(c, upstreamId); err != nil {
+		return nil, err
+	}
+
+	url, err := c.getVal(s.path("upstreams", upstreamId, "endpoints", id))
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +525,7 @@ func (s *EtcdBackend) DeleteEndpoint(upstreamId, id string) error {
 }
 
 func (s *EtcdBackend) AddLocationMiddleware(hostname, locationId string, m *backend.MiddlewareInstance) (*backend.MiddlewareInstance, error) {
-	if err := s.ExpectLocation(hostname, locationId); err != nil {
+	if err := s.expectLocation(hostname, locationId); err != nil {
 		return nil, err
 	}
 	if m.Id == "" {
@@ -495,11 +543,19 @@ func (s *EtcdBackend) AddLocationMiddleware(hostname, locationId string, m *back
 }
 
 func (s *EtcdBackend) GetLocationMiddleware(hostname, locationId, mType, id string) (*backend.MiddlewareInstance, error) {
-	if err := s.ExpectLocation(hostname, locationId); err != nil {
+	return s.readLocationMiddleware(nil, hostname, locationId, mType, id)
+}
+
+func (s *EtcdBackend) readLocationMiddleware(c *lazyClient, hostname, locationId, mType, id string) (*backend.MiddlewareInstance, error) {
+	locationKey := s.path("hosts", hostname, "locations", locationId)
+	if err := s.initClient(locationKey, &c); err != nil {
+		return nil, err
+	}
+	if err := c.checkKeyExists(locationKey); err != nil {
 		return nil, err
 	}
 	backendKey := s.path("hosts", hostname, "locations", locationId, "middlewares", mType, id)
-	bytes, err := s.getVal(backendKey)
+	bytes, err := c.getVal(backendKey)
 	if err != nil {
 		return nil, err
 	}
@@ -519,7 +575,7 @@ func (s *EtcdBackend) UpdateLocationMiddleware(hostname, locationId string, m *b
 	if spec == nil {
 		return nil, fmt.Errorf("middleware type %s is not registered", m.Type)
 	}
-	if err := s.ExpectLocation(hostname, locationId); err != nil {
+	if err := s.expectLocation(hostname, locationId); err != nil {
 		return nil, err
 	}
 	if err := s.setJSONVal(s.path("hosts", hostname, "locations", locationId, "middlewares", m.Type, m.Id), m); err != nil {
@@ -529,7 +585,7 @@ func (s *EtcdBackend) UpdateLocationMiddleware(hostname, locationId string, m *b
 }
 
 func (s *EtcdBackend) DeleteLocationMiddleware(hostname, locationId, mType, id string) error {
-	if err := s.ExpectLocation(hostname, locationId); err != nil {
+	if err := s.expectLocation(hostname, locationId); err != nil {
 		return err
 	}
 	return s.deleteKey(s.path("hosts", hostname, "locations", locationId, "middlewares", mType, id))
@@ -605,7 +661,7 @@ func (s *EtcdBackend) parseHostChange(r *etcd.Response) (interface{}, error) {
 
 	switch r.Action {
 	case createA, setA:
-		host, err := s.readHost(hostname, false)
+		host, err := s.readHost(nil, hostname, false)
 		if err != nil {
 			return nil, err
 		}
@@ -632,7 +688,7 @@ func (s *EtcdBackend) parseHostKeyPairChange(r *etcd.Response) (interface{}, err
 		return nil, fmt.Errorf("unsupported action on the certificate: %s", r.Action)
 	}
 	hostname := out[1]
-	host, err := s.readHost(hostname, false)
+	host, err := s.readHost(nil, hostname, false)
 	if err != nil {
 		return nil, err
 	}
@@ -647,7 +703,7 @@ func (s *EtcdBackend) parseLocationChange(r *etcd.Response) (interface{}, error)
 		return nil, nil
 	}
 	hostname, locationId := out[1], out[2]
-	host, err := s.readHost(hostname, false)
+	host, err := s.readHost(nil, hostname, false)
 	if err != nil {
 		return nil, err
 	}
@@ -683,7 +739,7 @@ func (s *EtcdBackend) parseLocationUpstreamChange(r *etcd.Response) (interface{}
 	}
 
 	hostname, locationId := out[1], out[2]
-	host, err := s.readHost(hostname, false)
+	host, err := s.readHost(nil, hostname, false)
 	if err != nil {
 		return nil, err
 	}
@@ -710,7 +766,7 @@ func (s *EtcdBackend) parseLocationOptionsChange(r *etcd.Response) (interface{},
 	}
 
 	hostname, locationId := out[1], out[2]
-	host, err := s.readHost(hostname, false)
+	host, err := s.readHost(nil, hostname, false)
 	if err != nil {
 		return nil, err
 	}
@@ -737,7 +793,7 @@ func (s *EtcdBackend) parseLocationPathChange(r *etcd.Response) (interface{}, er
 	}
 
 	hostname, locationId := out[1], out[2]
-	host, err := s.readHost(hostname, false)
+	host, err := s.readHost(nil, hostname, false)
 	if err != nil {
 		return nil, err
 	}
@@ -760,7 +816,7 @@ func (s *EtcdBackend) parseHostListenerChange(r *etcd.Response) (interface{}, er
 	}
 	hostname, listenerId := out[1], out[2]
 
-	host, err := s.readHost(hostname, false)
+	host, err := s.readHost(nil, hostname, false)
 	if err != nil {
 		return nil, err
 	}
@@ -857,7 +913,7 @@ func (s *EtcdBackend) parseMiddlewareChange(r *etcd.Response) (interface{}, erro
 	if spec == nil {
 		return nil, fmt.Errorf("unregistered middleware type %s", mType)
 	}
-	host, err := s.readHost(hostname, false)
+	host, err := s.readHost(nil, hostname, false)
 	if err != nil {
 		return nil, err
 	}
@@ -897,15 +953,18 @@ func (s *EtcdBackend) parseMiddlewareChange(r *etcd.Response) (interface{}, erro
 	return nil, fmt.Errorf("unsupported action on the rate: %s", r.Action)
 }
 
-func (s *EtcdBackend) readHosts(deep bool) ([]*backend.Host, error) {
+func (s *EtcdBackend) readHosts(c *lazyClient, deep bool) ([]*backend.Host, error) {
+	hostsKey := join(s.etcdKey, "hosts")
+	if err := s.initClient(hostsKey, &c); err != nil {
+		return nil, err
+	}
 	hosts := []*backend.Host{}
-	vals, err := s.getDirs(s.etcdKey, "hosts")
+	vals, err := c.getDirs(hostsKey)
 	if err != nil {
-
 		return nil, err
 	}
 	for _, hostKey := range vals {
-		host, err := s.readHost(suffix(hostKey), deep)
+		host, err := s.readHost(c, suffix(hostKey), deep)
 		if err != nil {
 			return nil, err
 		}
@@ -916,7 +975,7 @@ func (s *EtcdBackend) readHosts(deep bool) ([]*backend.Host, error) {
 
 func (s *EtcdBackend) upstreamUsedBy(upstreamId string) ([]*backend.Location, error) {
 	locations := []*backend.Location{}
-	hosts, err := s.readHosts(true)
+	hosts, err := s.readHosts(nil, true)
 	if err != nil {
 		return nil, err
 	}
@@ -964,85 +1023,6 @@ func (s *EtcdBackend) setVal(key string, val []byte) error {
 
 func (s *EtcdBackend) setStringVal(key string, val string) error {
 	return s.setVal(key, []byte(val))
-}
-
-func (s *EtcdBackend) getSealedVal(key string) ([]byte, error) {
-	if s.options.Box == nil {
-		return nil, fmt.Errorf("this backend does not support encryption")
-	}
-	bytes, err := s.getVal(key)
-	if err != nil {
-		return nil, err
-	}
-	sv, err := secret.SealedValueFromJSON([]byte(bytes))
-	if err != nil {
-		return nil, err
-	}
-	return s.options.Box.Open(sv)
-}
-
-func (s *EtcdBackend) getJSONVal(key string, in interface{}) error {
-	val, err := s.getVal(key)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal([]byte(val), in)
-}
-
-func (s *EtcdBackend) getVal(key string) (string, error) {
-	response, err := s.client.Get(key, false, false)
-	if err != nil {
-		return "", convertErr(err)
-	}
-
-	if isDir(response.Node) {
-		return "", &backend.NotFoundError{Message: fmt.Sprintf("missing key: %s", key)}
-	}
-	return response.Node.Value, nil
-}
-
-func (s *EtcdBackend) getDirs(keys ...string) ([]string, error) {
-	var out []string
-	response, err := s.client.Get(strings.Join(keys, "/"), true, true)
-	if err != nil {
-		if notFound(err) {
-			return out, nil
-		}
-		return nil, err
-	}
-
-	if response == nil || !isDir(response.Node) {
-		return out, nil
-	}
-
-	for _, srvNode := range response.Node.Nodes {
-		if isDir(srvNode) {
-			out = append(out, srvNode.Key)
-		}
-	}
-	return out, nil
-}
-
-func (s *EtcdBackend) getVals(keys ...string) ([]Pair, error) {
-	var out []Pair
-	response, err := s.client.Get(strings.Join(keys, "/"), true, true)
-	if err != nil {
-		if notFound(err) {
-			return out, nil
-		}
-		return nil, err
-	}
-
-	if !isDir(response.Node) {
-		return out, nil
-	}
-
-	for _, srvNode := range response.Node.Nodes {
-		if !isDir(srvNode) {
-			out = append(out, Pair{srvNode.Key, srvNode.Value})
-		}
-	}
-	return out, nil
 }
 
 func (s *EtcdBackend) createDir(key string) error {


### PR DESCRIPTION
In case if Vulcand serves hundred of locations, naive implementation issues
hundres of requests to Etcd to retrieve all hosts, what causes hosts endpoint
to take around 10 seconds to complete. This implementation uses caching
for local recursive reads what speeds up the hosts endpoint 10x and reduces
the load on etcd cluster.
