### PR TITLE
Rename plugin.Middleware to plugin.MiddlewareFactory

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -204,10 +204,10 @@ type LocationOptions struct {
 
 // Wrapper that contains information about this middleware backend-specific data used for serialization/deserialization
 type MiddlewareInstance struct {
-	Id         string
-	Priority   int
-	Type       string
-	Middleware plugin.Middleware
+	Id       string
+	Priority int
+	Type     string
+	Factory  plugin.MiddlewareFactory
 }
 
 func NewAddress(network, address string) (*Address, error) {

--- a/backend/json.go
+++ b/backend/json.go
@@ -156,15 +156,15 @@ func MiddlewareFromJSON(in []byte, getter plugin.SpecGetter) (*MiddlewareInstanc
 	if spec == nil {
 		return nil, fmt.Errorf("middleware of type %s is not supported", ms.Type)
 	}
-	m, err := spec.FromJSON(ms.Middleware)
+	factory, err := spec.FromJSON(ms.Middleware)
 	if err != nil {
 		return nil, err
 	}
 	return &MiddlewareInstance{
-		Id:         ms.Id,
-		Type:       ms.Type,
-		Middleware: m,
-		Priority:   ms.Priority,
+		Id:       ms.Id,
+		Type:     ms.Type,
+		Factory:  factory,
+		Priority: ms.Priority,
 	}, nil
 }
 

--- a/plugin/connlimit/connlimit.go
+++ b/plugin/connlimit/connlimit.go
@@ -52,12 +52,12 @@ func (cl *ConnLimit) String() string {
 	return fmt.Sprintf("connections=%d, variable=%s", cl.Connections, cl.Variable)
 }
 
-func FromOther(c ConnLimit) (plugin.Middleware, error) {
+func FromOther(c ConnLimit) (plugin.MiddlewareFactory, error) {
 	return NewConnLimit(c.Connections, c.Variable)
 }
 
 // Constructs the middleware from the command line
-func FromCli(c *cli.Context) (plugin.Middleware, error) {
+func FromCli(c *cli.Context) (plugin.MiddlewareFactory, error) {
 	return NewConnLimit(int64(c.Int("connections")), c.String("var"))
 }
 

--- a/plugin/middleware_test.go
+++ b/plugin/middleware_test.go
@@ -16,7 +16,7 @@ type MiddlewareSuite struct {
 var _ = Suite(&MiddlewareSuite{})
 
 func (s *MiddlewareSuite) TestVerifySignatureOK(c *C) {
-	fn := func(TestMiddleware) (Middleware, error) { return nil, nil }
+	fn := func(TestMiddleware) (MiddlewareFactory, error) { return nil, nil }
 	c.Assert(verifySignature(fn), IsNil)
 }
 
@@ -25,15 +25,15 @@ func (s *MiddlewareSuite) TestVerifySignatureIncompatibleFunctions(c *C) {
 	c.Assert(verifySignature(nil), NotNil)
 
 	// Pointers are not ok
-	fn := func(*TestMiddleware) (Middleware, error) { return nil, nil }
+	fn := func(*TestMiddleware) (MiddlewareFactory, error) { return nil, nil }
 	c.Assert(verifySignature(fn), NotNil)
 
 	// Just one input arg is needed
-	fn1 := func(TestMiddleware, int) (Middleware, error) { return nil, nil }
+	fn1 := func(TestMiddleware, int) (MiddlewareFactory, error) { return nil, nil }
 	c.Assert(verifySignature(fn1), NotNil)
 
 	// Return arguments are incorrect
-	fn2 := func(TestMiddleware) Middleware { return nil }
+	fn2 := func(TestMiddleware) MiddlewareFactory { return nil }
 	c.Assert(verifySignature(fn2), NotNil)
 
 	// First return argument is not middleware
@@ -41,7 +41,7 @@ func (s *MiddlewareSuite) TestVerifySignatureIncompatibleFunctions(c *C) {
 	c.Assert(verifySignature(fn3), NotNil)
 
 	// Second return argument is not error
-	fn4 := func(TestMiddleware) (Middleware, int) { return nil, 0 }
+	fn4 := func(TestMiddleware) (MiddlewareFactory, int) { return nil, 0 }
 	c.Assert(verifySignature(fn4), NotNil)
 
 }
@@ -107,7 +107,7 @@ func (*TestMiddleware) NewMiddleware() (middleware.Middleware, error) {
 func GetSpec() *MiddlewareSpec {
 	return &MiddlewareSpec{
 		Type: "test",
-		FromOther: func(b TestMiddleware) (Middleware, error) {
+		FromOther: func(b TestMiddleware) (MiddlewareFactory, error) {
 			if b.Field == "" {
 				return nil, fmt.Errorf("can not be empty")
 			}

--- a/plugin/ratelimit/ratelimit.go
+++ b/plugin/ratelimit/ratelimit.go
@@ -67,12 +67,12 @@ func (rl *RateLimit) String() string {
 		rl.Variable, time.Duration(rl.PeriodSeconds)*time.Second, rl.Requests, rl.Burst)
 }
 
-func FromOther(rate RateLimit) (plugin.Middleware, error) {
+func FromOther(rate RateLimit) (plugin.MiddlewareFactory, error) {
 	return NewRateLimit(rate.Requests, rate.Variable, rate.Burst, rate.PeriodSeconds)
 }
 
 // Constructs the middleware from the command line
-func FromCli(c *cli.Context) (plugin.Middleware, error) {
+func FromCli(c *cli.Context) (plugin.MiddlewareFactory, error) {
 	return NewRateLimit(c.Int("requests"), c.String("var"), int64(c.Int("burst")), c.Int("period"))
 }
 

--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -54,11 +54,11 @@ func (rewrite *RewriteInstance) ProcessRequest(r Request) (*http.Response, error
 func (*RewriteInstance) ProcessResponse(r Request, a Attempt) {
 }
 
-func FromOther(r Rewrite) (plugin.Middleware, error) {
+func FromOther(r Rewrite) (plugin.MiddlewareFactory, error) {
 	return NewRewriteInstance(r.Regexp, r.Replacement)
 }
 
-func FromCli(c *cli.Context) (plugin.Middleware, error) {
+func FromCli(c *cli.Context) (plugin.MiddlewareFactory, error) {
 	return NewRewriteInstance(c.String("regexp"), c.String("replacement"))
 }
 

--- a/server/mux.go
+++ b/server/mux.go
@@ -476,7 +476,7 @@ func (m *MuxServer) upsertLocationMiddleware(host *backend.Host, loc *backend.Lo
 	if location == nil {
 		return fmt.Errorf("%s not found", loc)
 	}
-	instance, err := mi.Middleware.NewMiddleware()
+	instance, err := mi.Factory.NewMiddleware()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
While reading the code I found it confusing that `plugin.Middleware` does not represent middleware per se, but rather a thing that creates middleware. So I suggest renaming it to `MiddlewareFactory` to improve readability.
