### PR TITLE
Updates for the rewrite middleware

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -81,8 +81,8 @@
 		},
 		{
 			"ImportPath": "github.com/mailgun/vulcan",
-			"Comment": "v0.1-232-gbbadab7",
-			"Rev": "bbadab7409a1624cdf483579d38d36d1c53d1599"
+			"Comment": "v0.1-235-gf1ce6b8",
+			"Rev": "f1ce6b87e5c58dfc5e98a481ee57daf4829483bb"
 		},
 		{
 			"ImportPath": "gopkg.in/check.v1",

--- a/Godeps/_workspace/src/github.com/mailgun/vulcan/netutils/netutils.go
+++ b/Godeps/_workspace/src/github.com/mailgun/vulcan/netutils/netutils.go
@@ -45,6 +45,12 @@ func RawPath(in string) (string, error) {
 	return path[:idx], nil
 }
 
+// RawURL returns URL built out of the provided request's Request-URI, to avoid un-escaping.
+// Note: it assumes that scheme and host for the provided request's URL are defined.
+func RawURL(request *http.Request) string {
+	return strings.Join([]string{request.URL.Scheme, "://", request.URL.Host, request.RequestURI}, "")
+}
+
 // Copies http headers from source to destination
 // does not overide, but adds multiple headers
 func CopyHeaders(dst, src http.Header) {

--- a/Godeps/_workspace/src/github.com/mailgun/vulcan/netutils/netutils_test.go
+++ b/Godeps/_workspace/src/github.com/mailgun/vulcan/netutils/netutils_test.go
@@ -1,10 +1,11 @@
 package netutils
 
 import (
-	. "github.com/mailgun/vulcand/Godeps/_workspace/src/gopkg.in/check.v1"
 	"net/http"
 	"net/url"
 	"testing"
+
+	. "github.com/mailgun/vulcand/Godeps/_workspace/src/gopkg.in/check.v1"
 )
 
 func TestUtils(t *testing.T) { TestingT(t) }
@@ -44,6 +45,11 @@ func (s *NetUtilsSuite) TestURLRawPath(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(out, Equals, v.Expected)
 	}
+}
+
+func (s *NetUtilsSuite) TestRawURL(c *C) {
+	request := &http.Request{URL: &url.URL{Scheme: "http", Host: "localhost:8080"}, RequestURI: "/foo/bar"}
+	c.Assert("http://localhost:8080/foo/bar", Equals, RawURL(request))
 }
 
 //Just to make sure we don't panic, return err and not


### PR DESCRIPTION
- Fixed middleware instantiation process.
- Use `RawURL()` instead of `URL.String()` method.
