### PR TITLE
Added X-Forward-Proto support in rewrite reles

### DIFF
--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -156,14 +156,14 @@ func CliFlags() []cli.Flag {
 
 func rawURL(request *http.Request) string {
 	scheme := "http"
-	if request.TLS != nil || isXForwardedHttps(request) {
+	if request.TLS != nil || isXForwardedHTTPS(request) {
 		scheme = "https"
 	}
 
 	return strings.Join([]string{scheme, "://", request.Host, request.RequestURI}, "")
 }
 
-func isXForwardedHttps(request *http.Request) bool {
+func isXForwardedHTTPS(request *http.Request) bool {
 	xForwardedProto := request.Header.Get("X-Forwarded-Proto")
 
 	return len(xForwardedProto) > 0 && xForwardedProto == "https"

--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -156,10 +156,17 @@ func CliFlags() []cli.Flag {
 
 func rawURL(request *http.Request) string {
 	scheme := "http"
-	if request.TLS != nil {
+	if request.TLS != nil || isXForwardedHttps(request) {
 		scheme = "https"
 	}
+
 	return strings.Join([]string{scheme, "://", request.Host, request.RequestURI}, "")
+}
+
+func isXForwardedHttps(request *http.Request) bool {
+	xForwardedProto := request.Header.Get("X-Forwarded-Proto")
+
+	return len(xForwardedProto) > 0 && xForwardedProto == "https"
 }
 
 type redirectHandler struct {


### PR DESCRIPTION
We use Vulcan behind a AWS Elastic Load Balancer for SSL offloading. For HTTP traffic we want to redirect to HTTPS, but because SSL is already handled by the ELB, the wrong URL is constructed in rewrite.go.

This fix uses the X-Forwarded-Proto header that is used by most proxies.

