### PR TITLE
Use correct waitIndex for Etcd engine Watch

### DIFF
--- a/engine/etcdng/etcd.go
+++ b/engine/etcdng/etcd.go
@@ -445,7 +445,7 @@ func (n *ng) Subscribe(changes chan interface{}, cancelC chan bool) error {
 				return err
 			}
 		}
-		waitIndex = response.Node.ModifiedIndex + 1
+		waitIndex = response.EtcdIndex + 1
 		log.Infof("%s", responseToString(response))
 		change, err := n.parseChange(response)
 		if err != nil {


### PR DESCRIPTION
    Until this change it was watching after just root node's
    ModifiedIndex, while the Watch was recursive, i.e. the real change's
    index might've been later. It was leading to errors manifesting in logs as follows:

    Nov 18 22:10:46.148 router ERROR PID:1
    [log.go:131:...Godeps/_workspace/src/github.com/mailgun/log.Errorf] unexpected error:
    401: The event in requested index is outdated and cleared
    (the requested history has been cleared [1116/1039]) [2115], stop watching

    ...and it was causing the router restart, leaking socket fd's in the process.

Signed-off-by: Mariusz Borsa mborsa@polyverse.io