### PR TITLE
When creating a new proxy, call Stop() on it if anything goes wrong

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -144,10 +144,18 @@ func (s *Supervisor) TopServers(key *engine.BackendKey) ([]engine.Server, error)
 
 func (s *Supervisor) init() error {
 	proxy, err := s.newProxy(s.lastId)
+	s.lastId += 1
 	if err != nil {
 		return err
 	}
-	s.lastId += 1
+
+	stopNewProxy := true
+
+	defer func() {
+		if stopNewProxy {
+			proxy.Stop(true)
+		}
+	}()
 
 	if err := initProxy(s.engine, proxy); err != nil {
 		return err
@@ -189,6 +197,7 @@ func (s *Supervisor) init() error {
 	}
 
 	// Watch and configure this instance of server
+	stopNewProxy = false
 	s.setCurrentProxy(proxy)
 	changesC := make(chan interface{})
 


### PR DESCRIPTION
If your etcd cluster is having a bad day, `Supervisor` will try to restart everything, and if `initProxy` has an error talking to etcd (or any other error), which it most definitely can, you will leak a partially initialized proxy/mux instance -- this is because in `proxy/mux.go`, on `New`, two goroutines are created, and they will keep the reference to the `mux` around until `Close` is called.

Don't love the style used here with a defer function, but this seemed the easiest way to get it done.

Should fix or at least partially fix #216 