### PR TITLE
Fix incorrect logger initialization in vbundle vctl template

### DIFF
--- a/vbundle/templates.go
+++ b/vbundle/templates.go
@@ -60,16 +60,20 @@ import (
 	"os"
 )
 
-var vulcanUrl string
-
 func main() {
-	log.Init([]*log.LogConfig{&log.LogConfig{Name: "console"}})
-
-    r, err := registry.GetRegistry()
+	console, err := log.NewLogger(log.Config{"console", "info"})
 	if err != nil {
 		log.Errorf("Error: %s\n", err)
-        return
+		return
 	}
+	log.Init(console)
+
+	r, err := registry.GetRegistry()
+	if err != nil {
+		log.Errorf("Error: %s\n", err)
+		return
+	}
+
 	cmd := command.NewCommand(r)
 	if err := cmd.Run(os.Args); err != nil {
 		log.Errorf("Error: %s\n", err)


### PR DESCRIPTION
Hi there,

There is an issue in code generation template for bundle

```
$ vbundle init --middleware=github.com/vulcand/vulcand-auth/auth
$ go build -o vctl
# github.com/vulcand/vulcand-bundle-test/vctl
./main.go:11: cannot use []*"github.com/mailgun/log".Config literal (type []*"github.com/mailgun/log".Config) as type "github.com/mailgun/log".Logger in argument to "github.com/mailgun/log".Init:
	[]*"github.com/mailgun/log".Config does not implement "github.com/mailgun/log".Logger (missing FormatMessage method)
```