### PR TITLE
protect from '401: The event in requested index is outdated and cleared'

### DIFF
--- a/engine/etcdv2ng/etcd.go
+++ b/engine/etcdv2ng/etcd.go
@@ -13,13 +13,14 @@ import (
 	"time"
 
 	"crypto/x509"
+	"io/ioutil"
+
 	log "github.com/Sirupsen/logrus"
 	etcd "github.com/coreos/etcd/client"
 	"github.com/vulcand/vulcand/engine"
 	"github.com/vulcand/vulcand/plugin"
 	"github.com/vulcand/vulcand/secret"
 	"golang.org/x/net/context"
-	"io/ioutil"
 )
 
 type ng struct {
@@ -499,6 +500,12 @@ func (n *ng) Subscribe(changes chan interface{}, cancelC chan bool) error {
 	for {
 		response, err := w.Next(n.context)
 		if err != nil {
+			if err.(etcd.Error).Code == etcd.ErrorCodeEventIndexCleared {
+				log.Debugf("401 received: ignoring error")
+				w = n.kapi.Watcher(n.etcdKey, &etcd.WatcherOptions{AfterIndex: 0, Recursive: true})
+				continue
+			}
+
 			switch err {
 			case context.Canceled:
 				log.Infof("Stop watching: graceful shutdown")


### PR DESCRIPTION
We have a very busy etcd server which causes many 401s to be sent to vulcand. When vulcand supervisor reloads, it causes random 504s from our upstream proxy (AWS ELB in this case).

This commit ignores the 401 and re-creates a Watcher.
