### PR TITLE
Added client certificate support for backend

### DIFF
--- a/engine/tls.go
+++ b/engine/tls.go
@@ -111,18 +111,23 @@ func NewTLSConfig(s *TLSSettings) (*tls.Config, error) {
 
 	// Load CA certificates
 	caCertPool := x509.NewCertPool()
-	for _, certfile := range s.CACertFile {
-		caCert, err := ioutil.ReadFile(certfile)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to open CA cert file %s: %s", certfile, err)
+	if len(s.CACertFile) != 0 {
+		for _, certfile := range s.CACertFile {
+			caCert, err := ioutil.ReadFile(certfile)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to open CA cert file %s: %s", certfile, err)
+			}
+			caCertPool.AppendCertsFromPEM(caCert)
 		}
-		caCertPool.AppendCertsFromPEM(caCert)
 	}
 
 	// Load client certificate
-	cert, err := tls.LoadX509KeyPair(s.ClientCertFile, s.ClientKeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to load client key/cert pair: %s", err)
+	cert := tls.Certificate
+	if s.ClientCertFile != "" && s.ClientKeyFile != "" {
+		cert, err = tls.LoadX509KeyPair(s.ClientCertFile, s.ClientKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to load client key/cert pair: %s", err)
+		}
 	}
 
 	return &tls.Config{

--- a/engine/tls.go
+++ b/engine/tls.go
@@ -122,7 +122,7 @@ func NewTLSConfig(s *TLSSettings) (*tls.Config, error) {
 	}
 
 	// Load client certificate
-	cert := tls.Certificate
+	var cert tls.Certificate
 	if s.ClientCertFile != "" && s.ClientKeyFile != "" {
 		cert, err = tls.LoadX509KeyPair(s.ClientCertFile, s.ClientKeyFile)
 		if err != nil {

--- a/engine/tls.go
+++ b/engine/tls.go
@@ -114,7 +114,7 @@ func NewTLSConfig(s *TLSSettings) (*tls.Config, error) {
 	for _, certfile := range s.CACertFile {
 		caCert, err := ioutil.ReadFile(certfile)
 		if err != nil {
-			fmt.Errorf("Failed to open CA cert file %s: %s", certfile, err)
+			return nil, fmt.Errorf("Failed to open CA cert file %s: %s", certfile, err)
 		}
 		caCertPool.AppendCertsFromPEM(caCert)
 	}
@@ -122,7 +122,7 @@ func NewTLSConfig(s *TLSSettings) (*tls.Config, error) {
 	// Load client certificate
 	cert, err := tls.LoadX509KeyPair(s.ClientCertFile, s.ClientKeyFile)
 	if err != nil {
-		fmt.Errorf("Failed to load client key/cert pair: %s", err)
+		return nil, fmt.Errorf("Failed to load client key/cert pair: %s", err)
 	}
 
 	return &tls.Config{

--- a/vctl/command/tls.go
+++ b/vctl/command/tls.go
@@ -15,6 +15,9 @@ func getTLSFlags() []cli.Flag {
 		cli.StringFlag{Name: "tlsSessionCache", Usage: "session cache type"},
 		cli.IntFlag{Name: "tlsSessionCacheCapacity", Usage: "session cache capacity"},
 		cli.StringSliceFlag{Name: "tlsCS", Usage: "optional list of preferred cipher suites", Value: &cli.StringSlice{}},
+		cli.StringFlag{Name: "clientCertFile", Usage: "client certificate file path"},
+		cli.StringFlag{Name: "clientKeyFile", Usage: "client certificate key file path"},
+		cli.StringSliceFlag{Name: "caCertFile", Usage: "trusted CA certificates file paths", Value: &cli.StringSlice{}},
 	}
 }
 
@@ -26,6 +29,9 @@ func getTLSSettings(c *cli.Context) (*engine.TLSSettings, error) {
 		MinVersion:               c.String("tlsMinV"),
 		MaxVersion:               c.String("tlsMaxV"),
 		CipherSuites:             c.StringSlice("tlsCS"),
+		ClientCertFile:           c.String("clientCertFile"),
+		ClientKeyFile:            c.String("clientKeyFile"),
+		CACertFile:               c.StringSlice("caCertFile"),
 	}
 	s.SessionCache.Type = c.String("tlsSessionCache")
 	if s.SessionCache.Type == engine.LRUCacheType {


### PR DESCRIPTION
Added additional client certificate tls options for backends. Can be used for example when the receiving side (upstream) performs certificate-based authentication.

Not sure if it was possible to make it on the middleware level since middleware works with HTTP requests while SSL connection is established on the lower level.

Also, it addresses the https://github.com/vulcand/vulcand/issues/261

**Short description and limitations**: This code assumes that certificates are stored **in the same place** across the installation and have the **same name**. In my case this assumption holds, but it would fail in the general case. 
I'm not sure how to make the same trick for the general case, probably by adding the ClientCert field to the host node.
