### PR TITLE
Added env config support

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -31,9 +31,9 @@ import (
 )
 
 func Run(registry *plugin.Registry) error {
-	options, err := ParseCommandLine()
+	options, err := ParseRunOptions()
 	if err != nil {
-		return fmt.Errorf("failed to parse command line: %s", err)
+		return fmt.Errorf("failed to parse run options: %s", err)
 	}
 	service := NewService(options, registry)
 	if err := service.Start(); err != nil {


### PR DESCRIPTION
Adopted coreos etcd envconfig lib to be used in vulcand.
Mixed config is possible, flags have priority to the env vars
Example usage:
`VULCAND_APIINTERFACE=0.0.0.0 VULCAND_PORT=8185 vulcand -logSeverity debug`

Note: ParseCommandLine() renamed to ParseRunOptions() for the sake of correctness since it parses not only CLI input, but also env vars now

Addressed in https://github.com/vulcand/vulcand/issues/75
