### PR TITLE
Connection Tracker pluggable

### DIFF
--- a/conntracker/conntracker.go
+++ b/conntracker/conntracker.go
@@ -1,0 +1,13 @@
+package conntracker
+
+import (
+	"net"
+	"net/http"
+)
+
+type ConnectionTracker interface {
+	RegisterStateChange(conn net.Conn, prev http.ConnState, cur http.ConnState)
+	Counts() ConnectionStats
+}
+
+type ConnectionStats map[http.ConnState]map[string]int64

--- a/plugin/middleware.go
+++ b/plugin/middleware.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/codegangsta/cli"
 	"github.com/vulcand/route"
+	"github.com/vulcand/vulcand/conntracker"
 	"github.com/vulcand/vulcand/router"
 	"net/http"
 	"reflect"
@@ -54,9 +55,10 @@ type SpecGetter func(string) *MiddlewareSpec
 
 // Registry contains currently registered middlewares and used to support pluggable middlewares across all modules of the vulcand
 type Registry struct {
-	specs    []*MiddlewareSpec
-	notFound Middleware
-	router   router.Router
+	specs       []*MiddlewareSpec
+	notFound    Middleware
+	router      router.Router
+	connTracker conntracker.ConnectionTracker
 }
 
 func NewRegistry() *Registry {
@@ -109,6 +111,15 @@ func (r *Registry) SetRouter(router router.Router) error {
 
 func (r *Registry) GetRouter() router.Router {
 	return r.router
+}
+
+func (r *Registry) SetConnectionTracker(connTracker conntracker.ConnectionTracker) error {
+	r.connTracker = connTracker
+	return nil
+}
+
+func (r *Registry) GetConnectionTracker() conntracker.ConnectionTracker {
+	return r.connTracker
 }
 
 func verifySignature(fn interface{}) error {

--- a/proxy/mux.go
+++ b/proxy/mux.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mailgun/metrics"
 	"github.com/mailgun/timetools"
 	"github.com/vulcand/route"
+	"github.com/vulcand/vulcand/conntracker"
 )
 
 // mux is capable of listening on multiple interfaces, graceful shutdowns and updating TLS certificates
@@ -47,7 +48,7 @@ type mux struct {
 	state muxState
 
 	// Connection watcher
-	connTracker *connTracker
+	connTracker conntracker.ConnectionTracker
 
 	// stopC used for global broadcast to all proxy systems that it's closed
 	stopC chan struct{}
@@ -73,7 +74,7 @@ func New(id int, st stapler.Stapler, o Options) (*mux, error) {
 		options: o,
 
 		router:      o.Router,
-		connTracker: newConnTracker(),
+		connTracker: o.ConnectionTracker,
 
 		servers:   make(map[engine.ListenerKey]*srv),
 		backends:  make(map[engine.BackendKey]*backend),
@@ -608,6 +609,9 @@ func setDefaults(o Options) Options {
 	}
 	if o.Router == nil {
 		o.Router = route.NewMux()
+	}
+	if o.ConnectionTracker == nil {
+		o.ConnectionTracker = newDefaultConnTracker()
 	}
 	return o
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mailgun/metrics"
 	"github.com/mailgun/timetools"
+	"github.com/vulcand/vulcand/conntracker"
 	"github.com/vulcand/vulcand/engine"
 	"github.com/vulcand/vulcand/plugin"
 	"github.com/vulcand/vulcand/router"
@@ -58,6 +59,7 @@ type Options struct {
 	TimeProvider       timetools.TimeProvider
 	NotFoundMiddleware plugin.Middleware
 	Router             router.Router
+	ConnectionTracker  conntracker.ConnectionTracker
 }
 
 type NewProxyFn func(id int) (Proxy, error)

--- a/proxy/srv.go
+++ b/proxy/srv.go
@@ -127,7 +127,7 @@ but the file descriptor that was given corresponded to a listener of type %T. Mo
 		manners.Options{
 			Server:       s.newHTTPServer(),
 			Listener:     listener,
-			StateHandler: s.mux.connTracker.onStateChange,
+			StateHandler: s.mux.connTracker.RegisterStateChange,
 		})
 	s.state = srvStateHijacked
 	return nil
@@ -248,7 +248,7 @@ func (s *srv) start() error {
 			manners.Options{
 				Server:       s.newHTTPServer(),
 				Listener:     listener,
-				StateHandler: s.mux.connTracker.onStateChange,
+				StateHandler: s.mux.connTracker.RegisterStateChange,
 			})
 		s.state = srvStateActive
 		go s.serve(s.srv)

--- a/proxy/stats.go
+++ b/proxy/stats.go
@@ -17,7 +17,7 @@ func (mx *mux) emitMetrics() error {
 	c := mx.options.MetricsClient
 
 	// Emit connection stats
-	counts := mx.connTracker.counts()
+	counts := mx.connTracker.Counts()
 	for state, values := range counts {
 		for addr, count := range values {
 			c.Gauge(c.Metric("conns", addr, state.String()), count, 1)

--- a/service/service.go
+++ b/service/service.go
@@ -325,6 +325,7 @@ func (s *Service) newProxy(id int) (proxy.Proxy, error) {
 		DefaultListener:    constructDefaultListener(s.options),
 		NotFoundMiddleware: s.registry.GetNotFoundMiddleware(),
 		Router:             s.registry.GetRouter(),
+		ConnectionTracker:  s.registry.GetConnectionTracker(),
 	})
 }
 


### PR DESCRIPTION
This change originated from https://github.com/vulcand/vulcand/issues/256

In good faith of backward compatibility, as well as giving consumers the option to do different things with the state changes.

For some, they may gather metrics, or post logs on how long a connection lasts, or may store a frequency, etc. etc.