### PR TITLE
Fix broken plugin/trace test

### DIFF
--- a/plugin/trace/trace_test.go
+++ b/plugin/trace/trace_test.go
@@ -17,6 +17,15 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+func setUnixSocket(c *C) *net.UnixConn {
+	os.Remove("/tmp/vulcand_trace_test.sock")
+	unixAddr, err := net.ResolveUnixAddr("unixgram", "/tmp/vulcand_trace_test.sock")
+	c.Assert(err, IsNil)
+	conn, err := net.ListenUnixgram("unixgram", unixAddr)
+	c.Assert(err, IsNil)
+	return conn
+}
+
 func TestTrace(t *testing.T) { TestingT(t) }
 
 type TraceSuite struct {
@@ -31,6 +40,9 @@ func (s *TraceSuite) TestSpecIsOK(c *C) {
 }
 
 func (s *TraceSuite) TestGoodAddr(c *C) {
+	conn := setUnixSocket(c)
+	defer conn.Close()
+
 	vals := []string{
 		// host + port format
 		"syslog://localhost:5000",
@@ -39,9 +51,9 @@ func (s *TraceSuite) TestGoodAddr(c *C) {
 		"syslog://localhost:5000?f=LOG_LOCAL0&sev=DEBUG",
 
 		// local socket format
-		"syslog:///dev/log",
-		"syslog:///dev/log?f=MAIL",
-		"syslog:///dev/log?f=LOG_LOCAL0",
+		"syslog:///tmp/vulcand_trace_test.sock",
+		"syslog:///tmp/vulcand_trace_test.sock?f=MAIL",
+		"syslog:///tmp/vulcand_trace_test.sock?f=LOG_LOCAL0",
 
 		// default syslog
 		"syslog://",
@@ -68,11 +80,7 @@ func (s *TraceSuite) TestBadAddr(c *C) {
 }
 
 func (s *TraceSuite) TestHandler(c *C) {
-	os.Remove("/tmp/vulcand_trace_test.sock")
-	unixAddr, err := net.ResolveUnixAddr("unixgram", "/tmp/vulcand_trace_test.sock")
-	c.Assert(err, IsNil)
-	conn, err := net.ListenUnixgram("unixgram", unixAddr)
-	c.Assert(err, IsNil)
+	conn := setUnixSocket(c)
 	defer conn.Close()
 
 	outC := make(chan []byte, 1000)
@@ -140,11 +148,11 @@ func (s *TraceSuite) TestNewFromCLI(c *C) {
 		c.Assert(err, IsNil)
 
 		t := out.(*Trace)
-		c.Assert(t.Addr, Equals, "syslog:///dev/log?sev=INFO&f=MAIL")
+		c.Assert(t.Addr, Equals, "syslog://localhost:5000?sev=INFO&f=MAIL")
 		c.Assert(t.ReqHeaders, DeepEquals, []string{"X-A", "X-B"})
 		c.Assert(t.RespHeaders, DeepEquals, []string{"X-C", "X-D"})
 	}
 	app.Flags = CliFlags()
-	app.Run([]string{"test", "--addr=syslog:///dev/log?sev=INFO&f=MAIL", "--reqHeader=X-A", "--reqHeader=X-B", "--respHeader=X-C", "--respHeader=X-D"})
+	app.Run([]string{"test", "--addr=syslog://localhost:5000?sev=INFO&f=MAIL", "--reqHeader=X-A", "--reqHeader=X-B", "--respHeader=X-C", "--respHeader=X-D"})
 	c.Assert(executed, Equals, true)
 }


### PR DESCRIPTION
plugin/trace test will fail if '/dev/log' is not present.
This file might be absent on:
* *BSD and Darwin; syslog uses '/var/run/log'
* Windows machines
* Linux using RSyslog with default options

This PR creates a unix socket to test against it