### PR TITLE
Speed up proxy initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 go:
-        - 1.5
-        - 1.6
-        - 1.7
+  - 1.5.4
+  - 1.6.3
+  - 1.7.1
 env:
-        - GO15VENDOREXPERIMENT=1
+  - GO15VENDOREXPERIMENT=1
 script:
-        - go test $(go list ./... | grep -v '/vendor/')
+  - go test -v $(go list ./... | grep -v '/vendor/')

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -84,7 +84,7 @@ type Engine interface {
 	// It should be a blocking function generating events from change.go to the changes channel.
 	// Each change should be an instance of the struct provided in events.go
 	// In  case if cancel channel is closed, the subscribe events should no longer be generated.
-	Subscribe(events chan interface{}, cancel chan bool) error
+	Subscribe(events chan interface{}, afterIdx uint64, cancel chan bool) error
 
 	// GetRegistry returns registry with the supported plugins. It should be stored by Engine instance.
 	GetRegistry() *plugin.Registry

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -14,6 +14,9 @@ type NewEngineFn func() (Engine, error)
 // Engines should pass the following acceptance suite to be compatible:
 // engine/test/suite.go, see engine/etcdng/etcd_test.go and engine/memng/mem_test.go for details
 type Engine interface {
+	// GetSnapshot returns a complete configuration snapshot.
+	GetSnapshot() (*Snapshot, error)
+
 	// GetHosts returns list of hosts registered in the storage engine
 	// Returns empty list in case if there are no hosts.
 	GetHosts() ([]Host, error)

--- a/engine/etcdng/etcd.go
+++ b/engine/etcdng/etcd.go
@@ -63,6 +63,10 @@ func (s *ng) Close() {
 	}
 }
 
+func (n *ng) GetSnapshot() (*engine.Snapshot, error) {
+	return nil, nil
+}
+
 func (n *ng) GetLogSeverity() log.Level {
 	return n.logsev
 }

--- a/engine/etcdng/etcd.go
+++ b/engine/etcdng/etcd.go
@@ -434,9 +434,9 @@ func (n *ng) backendUsedBy(bk engine.BackendKey) ([]engine.Frontend, error) {
 
 // Subscribe watches etcd changes and generates structured events telling vulcand to add or delete frontends, hosts etc.
 // It is a blocking function.
-func (n *ng) Subscribe(changes chan interface{}, cancelC chan bool) error {
+func (n *ng) Subscribe(changes chan interface{}, afterIdx uint64, cancelC chan bool) error {
 	// This index helps us to get changes in sequence, as they were performed by clients.
-	waitIndex := uint64(0)
+	waitIndex := afterIdx
 	for {
 		response, err := n.client.Watch(n.etcdKey, waitIndex, true, nil, cancelC)
 		if err != nil {

--- a/engine/etcdng/etcd.go
+++ b/engine/etcdng/etcd.go
@@ -64,7 +64,7 @@ func (s *ng) Close() {
 }
 
 func (n *ng) GetSnapshot() (*engine.Snapshot, error) {
-	return nil, nil
+	return nil, &engine.SnapshotNotSupportedError{}
 }
 
 func (n *ng) GetLogSeverity() log.Level {

--- a/engine/etcdng/etcd_test.go
+++ b/engine/etcdng/etcd_test.go
@@ -85,7 +85,7 @@ func (s *EtcdSuite) SetUpTest(c *C) {
 
 	s.changesC = make(chan interface{})
 	s.stopC = make(chan bool)
-	go s.ng.Subscribe(s.changesC, s.stopC)
+	go s.ng.Subscribe(s.changesC, 0, s.stopC)
 
 	s.suite.ChangesC = s.changesC
 	s.suite.Engine = engine

--- a/engine/etcdv2ng/etcd.go
+++ b/engine/etcdv2ng/etcd.go
@@ -72,7 +72,7 @@ func (n *ng) GetSnapshot() (*engine.Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
-	var s engine.Snapshot
+	s := &engine.Snapshot{Index: response.Index}
 	for _, node := range response.Node.Nodes {
 		switch suffix(node.Key) {
 		case "frontends":
@@ -97,7 +97,7 @@ func (n *ng) GetSnapshot() (*engine.Snapshot, error) {
 			}
 		}
 	}
-	return &s, nil
+	return s, nil
 }
 
 func (n *ng) parseFrontends(node *etcd.Node) ([]engine.FrontendSpec, error) {
@@ -635,8 +635,8 @@ func (n *ng) backendUsedBy(bk engine.BackendKey) ([]engine.Frontend, error) {
 
 // Subscribe watches etcd changes and generates structured events telling vulcand to add or delete frontends, hosts etc.
 // It is a blocking function.
-func (n *ng) Subscribe(changes chan interface{}, cancelC chan bool) error {
-	w := n.kapi.Watcher(n.etcdKey, &etcd.WatcherOptions{AfterIndex: 0, Recursive: true})
+func (n *ng) Subscribe(changes chan interface{}, afterIdx uint64, cancelC chan bool) error {
+	w := n.kapi.Watcher(n.etcdKey, &etcd.WatcherOptions{AfterIndex: afterIdx, Recursive: true})
 	for {
 		response, err := w.Next(n.context)
 		if err != nil {

--- a/engine/etcdv2ng/etcd_test.go
+++ b/engine/etcdv2ng/etcd_test.go
@@ -89,7 +89,7 @@ func (s *EtcdSuite) SetUpTest(c *C) {
 
 	s.changesC = make(chan interface{})
 	s.stopC = make(chan bool)
-	go s.ng.Subscribe(s.changesC, s.stopC)
+	go s.ng.Subscribe(s.changesC, 0, s.stopC)
 
 	s.suite.ChangesC = s.changesC
 	s.suite.Engine = engine

--- a/engine/memng/mem.go
+++ b/engine/memng/mem.go
@@ -320,7 +320,7 @@ func (m *Mem) DeleteServer(sk engine.ServerKey) error {
 	return &engine.NotFoundError{}
 }
 
-func (m *Mem) Subscribe(changes chan interface{}, cancelC chan bool) error {
+func (m *Mem) Subscribe(changes chan interface{}, afterIdx uint64, cancelC chan bool) error {
 	for {
 		select {
 		case <-cancelC:

--- a/engine/memng/mem.go
+++ b/engine/memng/mem.go
@@ -53,7 +53,7 @@ func (m *Mem) Close() {
 }
 
 func (n *Mem) GetSnapshot() (*engine.Snapshot, error) {
-	return nil, nil
+	return nil, &engine.SnapshotNotSupportedError{}
 }
 
 func (m *Mem) GetLogSeverity() log.Level {

--- a/engine/memng/mem.go
+++ b/engine/memng/mem.go
@@ -52,6 +52,10 @@ func (m *Mem) emit(val interface{}) {
 func (m *Mem) Close() {
 }
 
+func (n *Mem) GetSnapshot() (*engine.Snapshot, error) {
+	return nil, nil
+}
+
 func (m *Mem) GetLogSeverity() log.Level {
 	return m.LogSeverity
 }

--- a/engine/memng/mem_test.go
+++ b/engine/memng/mem_test.go
@@ -23,7 +23,7 @@ func (s *MemSuite) SetUpTest(c *C) {
 
 	s.suite.ChangesC = make(chan interface{})
 	s.stopC = make(chan bool)
-	go engine.Subscribe(s.suite.ChangesC, s.stopC)
+	go engine.Subscribe(s.suite.ChangesC, 0, s.stopC)
 	s.suite.Engine = engine
 }
 

--- a/engine/model.go
+++ b/engine/model.go
@@ -738,6 +738,7 @@ type BackendSpec struct {
 
 // Snapshot represents system config at a given time.
 type Snapshot struct {
+	Index         uint64
 	FrontendSpecs []FrontendSpec
 	BackendSpecs  []BackendSpec
 	Hosts         []Host

--- a/engine/model.go
+++ b/engine/model.go
@@ -715,3 +715,23 @@ type TransportSettings struct {
 	KeepAlive TransportKeepAlive
 	TLS       *tls.Config
 }
+
+// FrontendSpec fully specifies a particular frontend.
+type FrontendSpec struct {
+	Frontend    Frontend
+	Middlewares []Middleware
+}
+
+// BackendSpec fully specifies a particular backend.
+type BackendSpec struct {
+	Backend Backend
+	Servers []Server
+}
+
+// Snapshot represents system config at a given time.
+type Snapshot struct {
+	FrontendSpecs []FrontendSpec
+	BackendSpecs  []BackendSpec
+	Hosts         []Host
+	Listeners     []Listener
+}

--- a/engine/model.go
+++ b/engine/model.go
@@ -591,7 +591,7 @@ func (n *NotFoundError) Error() string {
 	if n.Message != "" {
 		return n.Message
 	} else {
-		return "Object not found"
+		return "object not found"
 	}
 }
 
@@ -603,7 +603,7 @@ func (n *InvalidFormatError) Error() string {
 	if n.Message != "" {
 		return n.Message
 	} else {
-		return "Invalid format"
+		return "invalid format"
 	}
 }
 
@@ -613,6 +613,14 @@ type AlreadyExistsError struct {
 
 func (n *AlreadyExistsError) Error() string {
 	return n.Message
+}
+
+type SnapshotNotSupportedError struct {
+	Message string
+}
+
+func (e *SnapshotNotSupportedError) Error() string {
+	return e.Message
 }
 
 type Counters struct {

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -313,12 +313,12 @@ func (s *Supervisor) Stop(wait bool) {
 func initProxy(ng engine.Engine, p proxy.Proxy) error {
 	snapshot, err := ng.GetSnapshot()
 	if err != nil {
+		// Some legacy engines do not implement `GetSnapshot` so we resort to
+		// a slow method of obtaining configuration from Etcd.
+		if _, ok := err.(*engine.SnapshotNotSupportedError); ok {
+			return initProxySlow(ng, p)
+		}
 		return err
-	}
-	// Some legacy engines do not implement `GetSnapshot` so we resort to old
-	// and slow method of obtaining configuration from Etcd piece by piece.
-	if snapshot == nil {
-		return initProxySlow(ng, p)
 	}
 	for _, h := range snapshot.Hosts {
 		if err := p.UpsertHost(h); err != nil {


### PR DESCRIPTION
### Problem

We noticed that sometimes it takes proxy up to 5 minutes (!!!) to startup on our system. Turned out the reason for that was inefficient initial configuration loading from Etcd, that was performed one key at a time.

### Solution

`GetSnapshot` method was introcuded to `engine.Engine` interface. That supposed to efficiently read entire configuration from an engine. This method is only implemented for `etcdv2ng` engine. For other engines stub implementations are provided returning `nil`. On proxy initialization we first call `GetSnapshot` and if `nil` is returned then resort to old style initialization logic.

This solution brought the startup time from about 5 minutes to about 30 seconds on our system.