### PR TITLE
Update cli.Action -> cli.ActionFunc signature

### DIFF
--- a/plugin/cbreaker/spec_test.go
+++ b/plugin/cbreaker/spec_test.go
@@ -168,7 +168,7 @@ func (s *SpecSuite) TestNewCircuitBreakerFromCli(c *C) {
 	app := cli.NewApp()
 	app.Name = "test"
 	executed := false
-	app.Action = func(ctx *cli.Context) {
+	app.Action = func(ctx *cli.Context) error {
 		executed = true
 		out, err := FromCli(ctx)
 		c.Assert(out, NotNil)
@@ -182,6 +182,8 @@ func (s *SpecSuite) TestNewCircuitBreakerFromCli(c *C) {
 		c.Assert(cl.FallbackDuration, Equals, 11*time.Second)
 		c.Assert(cl.RecoveryDuration, Equals, 12*time.Second)
 		c.Assert(cl.CheckPeriod, Equals, 14*time.Millisecond)
+
+		return nil
 	}
 	app.Flags = CliFlags()
 	app.Run([]string{"test",

--- a/plugin/connlimit/connlimit_test.go
+++ b/plugin/connlimit/connlimit_test.go
@@ -57,7 +57,7 @@ func (s *ConnLimitSuite) TestNewConnLimitFromCli(c *C) {
 	app := cli.NewApp()
 	app.Name = "test"
 	executed := false
-	app.Action = func(ctx *cli.Context) {
+	app.Action = func(ctx *cli.Context) error {
 		executed = true
 		out, err := FromCli(ctx)
 		c.Assert(out, NotNil)
@@ -66,6 +66,8 @@ func (s *ConnLimitSuite) TestNewConnLimitFromCli(c *C) {
 		cl := out.(*ConnLimit)
 		c.Assert(cl.Variable, Equals, "client.ip")
 		c.Assert(cl.Connections, Equals, int64(10))
+
+		return nil
 	}
 	app.Flags = CliFlags()
 	app.Run([]string{"test", "--var=client.ip", "--connections=10"})

--- a/plugin/ratelimit/ratelimit_test.go
+++ b/plugin/ratelimit/ratelimit_test.go
@@ -131,7 +131,7 @@ func (s *RateLimitSuite) TestFromCli(c *C) {
 	app.Name = "test"
 	app.Flags = GetSpec().CliFlags
 	executed := false
-	app.Action = func(ctx *cli.Context) {
+	app.Action = func(ctx *cli.Context) error {
 		executed = true
 		out, err := FromCli(ctx)
 		c.Assert(out, NotNil)
@@ -141,6 +141,8 @@ func (s *RateLimitSuite) TestFromCli(c *C) {
 		m, err := rl.NewHandler(nil)
 		c.Assert(m, NotNil)
 		c.Assert(err, IsNil)
+
+		return nil
 	}
 	app.Run([]string{"test", "--var=client.ip", "--requests=10", "--burst=3", "--period=4"})
 	c.Assert(executed, Equals, true)

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -57,7 +57,7 @@ func (s *RewriteSuite) TestNewRewriteFromCLIOK(c *C) {
 	app := cli.NewApp()
 	app.Name = "test"
 	executed := false
-	app.Action = func(ctx *cli.Context) {
+	app.Action = func(ctx *cli.Context) error {
 		executed = true
 		out, err := FromCli(ctx)
 		c.Assert(out, NotNil)
@@ -69,6 +69,8 @@ func (s *RewriteSuite) TestNewRewriteFromCLIOK(c *C) {
 		c.Assert(rw.Replacement, Equals, "$1")
 		c.Assert(rw.RewriteBody, Equals, true)
 		c.Assert(rw.Redirect, Equals, true)
+
+		return nil
 	}
 	app.Flags = CliFlags()
 	app.Run([]string{"test", "--regexp=^/foo(.*)", "--replacement=$1", "--rewriteBody", "--redirect"})

--- a/plugin/trace/trace_test.go
+++ b/plugin/trace/trace_test.go
@@ -141,7 +141,7 @@ func (s *TraceSuite) TestNewFromCLI(c *C) {
 	app := cli.NewApp()
 	app.Name = "test"
 	executed := false
-	app.Action = func(ctx *cli.Context) {
+	app.Action = func(ctx *cli.Context) error {
 		executed = true
 		out, err := FromCli(ctx)
 		c.Assert(out, NotNil)
@@ -151,6 +151,8 @@ func (s *TraceSuite) TestNewFromCLI(c *C) {
 		c.Assert(t.Addr, Equals, "syslog://localhost:5000?sev=INFO&f=MAIL")
 		c.Assert(t.ReqHeaders, DeepEquals, []string{"X-A", "X-B"})
 		c.Assert(t.RespHeaders, DeepEquals, []string{"X-C", "X-D"})
+
+		return nil
 	}
 	app.Flags = CliFlags()
 	app.Run([]string{"test", "--addr=syslog://localhost:5000?sev=INFO&f=MAIL", "--reqHeader=X-A", "--reqHeader=X-B", "--respHeader=X-C", "--respHeader=X-D"})

--- a/vctl/command/log.go
+++ b/vctl/command/log.go
@@ -1,9 +1,10 @@
 package command
 
 import (
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"strings"
 )
 
 func NewLogCommand(cmd *Command) cli.Command {

--- a/vctl/command/print.go
+++ b/vctl/command/print.go
@@ -106,3 +106,7 @@ func (cmd *Command) printFrontend(f *engine.Frontend, ms []engine.Middleware) {
 func writeS(w io.Writer, v string) {
 	w.Write([]byte(v))
 }
+
+func PrintError(cmd *Command, err error) {
+	cmd.printError(err)
+}

--- a/vctl/command/print.go
+++ b/vctl/command/print.go
@@ -11,7 +11,7 @@ import (
 
 func (cmd *Command) printResult(format string, in interface{}, err error) {
 	if err != nil {
-		cmd.printError(err)
+		cmd.PrintError(err)
 	} else {
 		cmd.printOk(format, fmt.Sprintf("%v", in))
 	}
@@ -19,13 +19,13 @@ func (cmd *Command) printResult(format string, in interface{}, err error) {
 
 func (cmd *Command) printStatus(in interface{}, err error) {
 	if err != nil {
-		cmd.printError(err)
+		cmd.PrintError(err)
 	} else {
 		cmd.printOk("%s", in)
 	}
 }
 
-func (cmd *Command) printError(err error) {
+func (cmd *Command) PrintError(err error) {
 	fmt.Fprint(cmd.out, goterm.Color(fmt.Sprintf("ERROR: %s", err), goterm.RED)+"\n")
 }
 
@@ -105,8 +105,4 @@ func (cmd *Command) printFrontend(f *engine.Frontend, ms []engine.Middleware) {
 
 func writeS(w io.Writer, v string) {
 	w.Write([]byte(v))
-}
-
-func PrintError(cmd *Command, err error) {
-	cmd.printError(err)
 }

--- a/vctl/command/status.go
+++ b/vctl/command/status.go
@@ -35,13 +35,13 @@ func (cmd *Command) overviewAction(backendId string, watch int, limit int) {
 	for {
 		frontends, err := cmd.client.TopFrontends(bk, limit)
 		if err != nil {
-			cmd.printError(err)
+			cmd.PrintError(err)
 			frontends = []engine.Frontend{}
 		}
 
 		servers, err := cmd.client.TopServers(bk, limit)
 		if err != nil {
-			cmd.printError(err)
+			cmd.PrintError(err)
 			servers = []engine.Server{}
 		}
 		t := time.Now()

--- a/vctl/main.go
+++ b/vctl/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/vulcand/vulcand/plugin/registry"
 	"github.com/vulcand/vulcand/vctl/command"
 )
@@ -14,6 +13,6 @@ func main() {
 	cmd := command.NewCommand(registry.GetRegistry())
 	err := cmd.Run(os.Args)
 	if err != nil {
-		log.Errorf("error: %s\n", err)
+		command.PrintError(cmd, err)
 	}
 }

--- a/vctl/main.go
+++ b/vctl/main.go
@@ -13,6 +13,6 @@ func main() {
 	cmd := command.NewCommand(registry.GetRegistry())
 	err := cmd.Run(os.Args)
 	if err != nil {
-		command.PrintError(cmd, err)
+		cmd.PrintError(err)
 	}
 }


### PR DESCRIPTION
As of urfave/cli version 1.15 `cli.App.Action` signature was deprecated, and instead we should use `func(*cli.Context) error`, as defined by `cli.ActionFunc`.
This commit update the funciton signature.