### PR TITLE
Get rid of vctl deprecation warning

### DIFF
--- a/vctl/command/backend.go
+++ b/vctl/command/backend.go
@@ -44,50 +44,48 @@ func NewBackendCommand(cmd *Command) cli.Command {
 	}
 }
 
-func (cmd *Command) upsertBackendAction(c *cli.Context) {
+func (cmd *Command) upsertBackendAction(c *cli.Context) error {
 	settings, err := getBackendSettings(c)
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	b, err := engine.NewHTTPBackend(c.String("id"), settings)
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printResult("%s upserted", b, cmd.client.UpsertBackend(*b))
+	return nil
 }
 
-func (cmd *Command) deleteBackendAction(c *cli.Context) {
+func (cmd *Command) deleteBackendAction(c *cli.Context) error {
 	if err := cmd.client.DeleteBackend(engine.BackendKey{Id: c.String("id")}); err != nil {
-		cmd.printError(err)
-	} else {
-		cmd.printOk("backend deleted")
+		return err
 	}
+	cmd.printOk("backend deleted")
+	return nil
 }
 
-func (cmd *Command) printBackendAction(c *cli.Context) {
+func (cmd *Command) printBackendAction(c *cli.Context) error {
 	bk := engine.BackendKey{Id: c.String("id")}
 	b, err := cmd.client.GetBackend(bk)
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	srvs, err := cmd.client.GetServers(bk)
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printBackend(b, srvs)
+	return nil
 }
 
-func (cmd *Command) listBackendsAction(c *cli.Context) {
+func (cmd *Command) listBackendsAction(c *cli.Context) error {
 	out, err := cmd.client.GetBackends()
 	if err != nil {
-		cmd.printError(err)
-	} else {
-		cmd.printBackends(out)
+		return err
 	}
+	cmd.printBackends(out)
+	return nil
 }
 
 func getBackendSettings(c *cli.Context) (engine.HTTPBackendSettings, error) {

--- a/vctl/command/frontend.go
+++ b/vctl/command/frontend.go
@@ -48,56 +48,53 @@ func NewFrontendCommand(cmd *Command) cli.Command {
 	}
 }
 
-func (cmd *Command) printFrontendsAction(c *cli.Context) {
+func (cmd *Command) printFrontendsAction(c *cli.Context) error {
 	fs, err := cmd.client.GetFrontends()
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printFrontends(fs)
+	return nil
 }
 
-func (cmd *Command) printFrontendAction(c *cli.Context) {
+func (cmd *Command) printFrontendAction(c *cli.Context) error {
 	fk := engine.FrontendKey{Id: c.String("id")}
 	frontend, err := cmd.client.GetFrontend(fk)
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 
 	ms, err := cmd.client.GetMiddlewares(fk)
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printFrontend(frontend, ms)
+	return nil
 }
 
-func (cmd *Command) upsertFrontendAction(c *cli.Context) {
+func (cmd *Command) upsertFrontendAction(c *cli.Context) error {
 	settings, err := getFrontendSettings(c)
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	f, err := engine.NewHTTPFrontend(route.NewMux(), c.String("id"), c.String("b"), c.String("route"), settings)
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	if err := cmd.client.UpsertFrontend(*f, c.Duration("ttl")); err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printOk("frontend upserted")
+	return nil
 }
 
-func (cmd *Command) deleteFrontendAction(c *cli.Context) {
+func (cmd *Command) deleteFrontendAction(c *cli.Context) error {
 	err := cmd.client.DeleteFrontend(engine.FrontendKey{Id: c.String("id")})
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printOk("frontend deleted")
+	return nil
 }
 
 func getFrontendSettings(c *cli.Context) (engine.HTTPFrontendSettings, error) {

--- a/vctl/command/host.go
+++ b/vctl/command/host.go
@@ -54,35 +54,33 @@ func NewHostCommand(cmd *Command) cli.Command {
 	}
 }
 
-func (cmd *Command) printHostsAction(c *cli.Context) {
+func (cmd *Command) printHostsAction(c *cli.Context) error {
 	hosts, err := cmd.client.GetHosts()
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printHosts(hosts)
+	return nil
 }
 
-func (cmd *Command) printHostAction(c *cli.Context) {
+func (cmd *Command) printHostAction(c *cli.Context) error {
 	host, err := cmd.client.GetHost(engine.HostKey{Name: c.String("name")})
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printHost(host)
+	return nil
 }
 
-func (cmd *Command) upsertHostAction(c *cli.Context) {
+func (cmd *Command) upsertHostAction(c *cli.Context) error {
 	host, err := engine.NewHost(c.String("name"), engine.HostSettings{})
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	if c.String("cert") != "" || c.String("privateKey") != "" {
 		keyPair, err := readKeyPair(c.String("cert"), c.String("privateKey"))
 		if err != nil {
-			cmd.printError(fmt.Errorf("failed to read key pair: %s", err))
-			return
+			return fmt.Errorf("failed to read key pair: %s", err)
 		}
 		host.Settings.KeyPair = keyPair
 	}
@@ -93,16 +91,16 @@ func (cmd *Command) upsertHostAction(c *cli.Context) {
 		Responders:         c.StringSlice("ocspResponder"),
 	}
 	if err := cmd.client.UpsertHost(*host); err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printOk("host added")
+	return nil
 }
 
-func (cmd *Command) deleteHostAction(c *cli.Context) {
+func (cmd *Command) deleteHostAction(c *cli.Context) error {
 	if err := cmd.client.DeleteHost(engine.HostKey{Name: c.String("name")}); err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printOk("host deleted")
+	return nil
 }

--- a/vctl/command/listener.go
+++ b/vctl/command/listener.go
@@ -48,49 +48,48 @@ func NewListenerCommand(cmd *Command) cli.Command {
 	}
 }
 
-func (cmd *Command) upsertListenerAction(c *cli.Context) {
+func (cmd *Command) upsertListenerAction(c *cli.Context) error {
 	var settings *engine.HTTPSListenerSettings
 	if c.String("proto") == engine.HTTPS {
 		s, err := getTLSSettings(c)
 		if err != nil {
-			cmd.printError(err)
-			return
+			return err
 		}
 		settings = &engine.HTTPSListenerSettings{TLS: *s}
 	}
 	listener, err := engine.NewListener(c.String("id"), c.String("proto"), c.String("net"), c.String("addr"), c.String("scope"), settings)
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	if err := cmd.client.UpsertListener(*listener); err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printOk("listener upserted")
+	return nil
 }
 
-func (cmd *Command) deleteListenerAction(c *cli.Context) {
+func (cmd *Command) deleteListenerAction(c *cli.Context) error {
 	if err := cmd.client.DeleteListener(engine.ListenerKey{Id: c.String("id")}); err != nil {
-		cmd.printError(err)
+		return err
 	}
 	cmd.printOk("listener deleted")
+	return nil
 }
 
-func (cmd *Command) printListenersAction(c *cli.Context) {
+func (cmd *Command) printListenersAction(c *cli.Context) error {
 	ls, err := cmd.client.GetListeners()
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printListeners(ls)
+	return nil
 }
 
-func (cmd *Command) printListenerAction(c *cli.Context) {
+func (cmd *Command) printListenerAction(c *cli.Context) error {
 	l, err := cmd.client.GetListener(engine.ListenerKey{Id: c.String("id")})
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printListener(l)
+	return nil
 }

--- a/vctl/command/log.go
+++ b/vctl/command/log.go
@@ -27,24 +27,23 @@ func NewLogCommand(cmd *Command) cli.Command {
 	}
 }
 
-func (cmd *Command) updateLogSeverityAction(c *cli.Context) {
+func (cmd *Command) updateLogSeverityAction(c *cli.Context) error {
 	sev, err := log.ParseLevel(strings.ToLower(c.String("severity")))
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	if err := cmd.client.UpdateLogSeverity(sev); err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printOk("log severity updated")
+	return nil
 }
 
-func (cmd *Command) getLogSeverityAction(c *cli.Context) {
+func (cmd *Command) getLogSeverityAction(c *cli.Context) error {
 	sev, err := cmd.client.GetLogSeverity()
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printOk("severity: %v", sev)
+	return nil
 }

--- a/vctl/command/middleware.go
+++ b/vctl/command/middleware.go
@@ -48,30 +48,28 @@ func makeMiddlewareCommands(cmd *Command, spec *plugin.MiddlewareSpec) cli.Comma
 	}
 }
 
-func makeUpsertMiddlewareAction(cmd *Command, spec *plugin.MiddlewareSpec) func(c *cli.Context) {
-	return func(c *cli.Context) {
+func makeUpsertMiddlewareAction(cmd *Command, spec *plugin.MiddlewareSpec) cli.ActionFunc {
+	return func(c *cli.Context) error {
 		m, err := spec.FromCli(c)
 		if err != nil {
-			cmd.printError(err)
-		} else {
-			mi := engine.Middleware{Id: c.String("id"), Middleware: m, Type: spec.Type, Priority: c.Int("priority")}
-			err := cmd.client.UpsertMiddleware(engine.FrontendKey{Id: c.String("frontend")}, mi, c.Duration("ttl"))
-			if err != nil {
-				cmd.printError(err)
-				return
-			}
-			cmd.printOk("%v upserted", spec.Type)
+			return err
 		}
+		mi := engine.Middleware{Id: c.String("id"), Middleware: m, Type: spec.Type, Priority: c.Int("priority")}
+		if err = cmd.client.UpsertMiddleware(engine.FrontendKey{Id: c.String("frontend")}, mi, c.Duration("ttl")); err != nil {
+			return err
+		}
+		cmd.printOk("%v upserted", spec.Type)
+		return nil
 	}
 }
 
-func makeDeleteMiddlewareAction(cmd *Command, spec *plugin.MiddlewareSpec) func(c *cli.Context) {
-	return func(c *cli.Context) {
+func makeDeleteMiddlewareAction(cmd *Command, spec *plugin.MiddlewareSpec) cli.ActionFunc {
+	return func(c *cli.Context) error {
 		mk := engine.MiddlewareKey{FrontendKey: engine.FrontendKey{Id: c.String("frontend")}, Id: c.String("id")}
 		if err := cmd.client.DeleteMiddleware(mk); err != nil {
-			cmd.printError(err)
-			return
+			return err
 		}
 		cmd.printOk("%v deleted", spec.Type)
+		return nil
 	}
 }

--- a/vctl/command/server.go
+++ b/vctl/command/server.go
@@ -51,42 +51,41 @@ func NewServerCommand(cmd *Command) cli.Command {
 	}
 }
 
-func (cmd *Command) upsertServerAction(c *cli.Context) {
+func (cmd *Command) upsertServerAction(c *cli.Context) error {
 	s, err := engine.NewServer(c.String("id"), c.String("url"))
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	if err := cmd.client.UpsertServer(engine.BackendKey{Id: c.String("backend")}, *s, c.Duration("ttl")); err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printOk("server upserted")
+	return nil
 }
 
-func (cmd *Command) deleteServerAction(c *cli.Context) {
+func (cmd *Command) deleteServerAction(c *cli.Context) error {
 	sk := engine.ServerKey{BackendKey: engine.BackendKey{Id: c.String("backend")}, Id: c.String("id")}
 	if err := cmd.client.DeleteServer(sk); err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printOk("Server %v deleted", sk.Id)
+	return nil
 }
 
-func (cmd *Command) printServersAction(c *cli.Context) {
+func (cmd *Command) printServersAction(c *cli.Context) error {
 	srvs, err := cmd.client.GetServers(engine.BackendKey{Id: c.String("backend")})
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printServers(srvs)
+	return nil
 }
 
-func (cmd *Command) printServerAction(c *cli.Context) {
+func (cmd *Command) printServerAction(c *cli.Context) error {
 	s, err := cmd.client.GetServer(engine.ServerKey{Id: c.String("id"), BackendKey: engine.BackendKey{Id: c.String("backend")}})
 	if err != nil {
-		cmd.printError(err)
-		return
+		return err
 	}
 	cmd.printServer(s)
+	return nil
 }

--- a/vctl/command/status.go
+++ b/vctl/command/status.go
@@ -22,8 +22,9 @@ func NewTopCommand(cmd *Command) cli.Command {
 	}
 }
 
-func (cmd *Command) topAction(c *cli.Context) {
+func (cmd *Command) topAction(c *cli.Context) error {
 	cmd.overviewAction(c.String("backend"), c.Int("refresh"), c.Int("limit"))
+	return nil
 }
 
 func (cmd *Command) overviewAction(backendId string, watch int, limit int) {


### PR DESCRIPTION
`vctl` command line utility was printing the following deprecation warning for every command: *DEPRECATED Action signature.  Must be `cli.ActionFunc`.  This is an error in the application.  Please contact the distributor of this application if this is not you.  See https://github.com/urfave/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature*. This PR updates the signature of action functions to meet the new type requirements.