### PR TITLE
Added Options.LogFormatter property

### DIFF
--- a/service/options.go
+++ b/service/options.go
@@ -27,8 +27,9 @@ type Options struct {
 	EtcdConsistency         string
 	EtcdSyncIntervalSeconds int64
 
-	Log         string
-	LogSeverity SeverityFlag
+	Log          string
+	LogSeverity  SeverityFlag
+	LogFormatter log.Formatter // if set, .Log will be ignored
 
 	ServerReadTimeout    time.Duration
 	ServerWriteTimeout   time.Duration
@@ -45,6 +46,7 @@ type Options struct {
 
 	DefaultListener bool
 }
+
 
 type SeverityFlag struct {
 	S log.Level


### PR DESCRIPTION
Add support for custom logrus formatters. If this property is set, vulcan will use this value when calling log.SetFormatter; otherwise, the default behavior (using the Options.Log string to determine the logrus formatter) will be used.