### PR TITLE
Run tests with race detector enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: go
 go:
-  - 1.5.4
   - 1.6.3
   - 1.7.1
-env:
-  - GO15VENDOREXPERIMENT=1
 script:
-  - go test -v $(go list ./... | grep -v '/vendor/')
+  - go test -v -p 1 --race $(go list ./... | grep -v '/vendor/')

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/vulcand/vulcand",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v69",
+	"GodepVersion": "v74",
 	"Packages": [
 		"./..."
 	],
@@ -73,8 +73,8 @@
 		},
 		{
 			"ImportPath": "github.com/mailgun/manners",
-			"Comment": "0.3.1-35-gfada451",
-			"Rev": "fada45142db3f93097ca917da107aa3fad0ffcb5"
+			"Comment": "0.4.0-17-ga585afd",
+			"Rev": "a585afd9d65c0e05f6c003f921e71ebc05074f4f"
 		},
 		{
 			"ImportPath": "github.com/mailgun/metrics",

--- a/engine/etcdv2ng/etcd.go
+++ b/engine/etcdv2ng/etcd.go
@@ -675,20 +675,14 @@ type MatcherFn func(*etcd.Response) (interface{}, error)
 
 // Dispatches etcd key changes changes to the etcd to the matching functions
 func (n *ng) parseChange(response *etcd.Response) (interface{}, error) {
+	// Order parsers from the most to the least frequently used.
 	matchers := []MatcherFn{
-		// Host updates
-		n.parseHostChange,
-
-		// Listener updates
-		n.parseListenerChange,
-
-		// Frontend updates
-		n.parseFrontendChange,
-		n.parseFrontendMiddlewareChange,
-
-		// Backend updates
-		n.parseBackendChange,
 		n.parseBackendServerChange,
+		n.parseBackendChange,
+		n.parseFrontendMiddlewareChange,
+		n.parseFrontendChange,
+		n.parseHostChange,
+		n.parseListenerChange,
 	}
 	for _, matcher := range matchers {
 		a, err := matcher(response)

--- a/proxy/mux.go
+++ b/proxy/mux.go
@@ -65,7 +65,7 @@ type mux struct {
 }
 
 func (m *mux) String() string {
-	return fmt.Sprintf("mux(%d, %v)", m.id, m.state)
+	return fmt.Sprintf("mux_%d", m.id)
 }
 
 func New(id int, st stapler.Stapler, o Options) (*mux, error) {

--- a/vendor/github.com/mailgun/manners/static.go
+++ b/vendor/github.com/mailgun/manners/static.go
@@ -3,14 +3,23 @@ package manners
 import (
 	"net"
 	"net/http"
+	"sync"
 )
 
-var defaultServer *GracefulServer
+var (
+	defaultServer     *GracefulServer
+	defaultServerLock = &sync.Mutex{}
+)
+
+func init() {
+	defaultServerLock.Lock()
+}
 
 // ListenAndServe provides a graceful version of the function provided by the
 // net/http package. Call Close() to stop the server.
 func ListenAndServe(addr string, handler http.Handler) error {
 	defaultServer = NewWithServer(&http.Server{Addr: addr, Handler: handler})
+	defaultServerLock.Unlock()
 	return defaultServer.ListenAndServe()
 }
 
@@ -18,6 +27,7 @@ func ListenAndServe(addr string, handler http.Handler) error {
 // net/http package. Call Close() to stop the server.
 func ListenAndServeTLS(addr string, certFile string, keyFile string, handler http.Handler) error {
 	defaultServer = NewWithServer(&http.Server{Addr: addr, Handler: handler})
+	defaultServerLock.Unlock()
 	return defaultServer.ListenAndServeTLS(certFile, keyFile)
 }
 
@@ -25,11 +35,13 @@ func ListenAndServeTLS(addr string, certFile string, keyFile string, handler htt
 // package. Call Close() to stop the server.
 func Serve(l net.Listener, handler http.Handler) error {
 	defaultServer = NewWithServer(&http.Server{Handler: handler})
+	defaultServerLock.Unlock()
 	return defaultServer.Serve(l)
 }
 
 // Shuts down the default server used by ListenAndServe, ListenAndServeTLS and
 // Serve. It returns true if it's the first time Close is called.
 func Close() bool {
+	defaultServerLock.Lock()
 	return defaultServer.Close()
 }


### PR DESCRIPTION
This PR enables race detector in tests. With the first run a couple of races were detected. Both are minor, but I fixed them anyway. One was actually in mailgun/manners, and another in `mux.String()`