### PR TITLE
Vulcand no longer starts up if there is no config in etcd

### DIFF
--- a/engine/etcdv2ng/etcd.go
+++ b/engine/etcdv2ng/etcd.go
@@ -70,6 +70,9 @@ func (n *ng) Close() {
 func (n *ng) GetSnapshot() (*engine.Snapshot, error) {
 	response, err := n.kapi.Get(n.context, n.etcdKey, &etcd.GetOptions{Recursive: true, Sort: true, Quorum: n.requireQuorum})
 	if err != nil {
+		if notFound(err) {
+			return &engine.Snapshot{}, nil
+		}
 		return nil, err
 	}
 	s := &engine.Snapshot{Index: response.Index}
@@ -431,6 +434,9 @@ func (n *ng) GetFrontends() ([]engine.Frontend, error) {
 	key := fmt.Sprintf("%s/frontends", n.etcdKey)
 	response, err := n.kapi.Get(n.context, key, &etcd.GetOptions{Recursive: true, Sort: true, Quorum: n.requireQuorum})
 	if err != nil {
+		if notFound(err) {
+			return []engine.Frontend{}, nil
+		}
 		return nil, err
 	}
 	frontendSpecs, err := n.parseFrontends(response.Node, true)
@@ -464,6 +470,9 @@ func (n *ng) DeleteFrontend(fk engine.FrontendKey) error {
 func (n *ng) GetBackends() ([]engine.Backend, error) {
 	response, err := n.kapi.Get(n.context, fmt.Sprintf("%s/backends", n.etcdKey), &etcd.GetOptions{Recursive: true, Sort: true, Quorum: n.requireQuorum})
 	if err != nil {
+		if notFound(err) {
+			return []engine.Backend{}, nil
+		}
 		return nil, err
 	}
 	backendSpecs, err := n.parseBackends(response.Node, true)


### PR DESCRIPTION
Attempting to start Vulcand for the first time with no data in etcd fails. The error log will print Service exited with error: service start failure: 100: Key not found (/vulcand) [7477]  and the application will exit.

This is due to GetSnapshot (introduced in e3f4eef8ad24f8ad46afc0af98a852f957d809f1) not checking for key not found.  

A similar regression was introduced in bc167c679135941224818ac183d9e9c634af6033 which caused GetBackends and GetFrontends to fail with a similar error.  This caused commands such as `vctl backend ls` to throw an Internal Server Error if no backends had been installed.

GetSnapshot now returns an empty snapshot if the key is not found.
GetFrontends and GetBackends now return an empty slice if the key is not found, same as before the change.
