### PR TITLE
Allow specifying of flush interval from Frontend Settings when streaming

### DIFF
--- a/engine/model.go
+++ b/engine/model.go
@@ -230,7 +230,7 @@ type HTTPFrontendSettings struct {
 	// Should Stream?
 	Stream bool
 	// How frequently should we flush the stream?
-	StreamFlushIntervalNanoSecs uint64
+	StreamFlushIntervalNanoSecs int64
 }
 
 func NewAddress(network, address string) (*Address, error) {

--- a/engine/model.go
+++ b/engine/model.go
@@ -229,6 +229,8 @@ type HTTPFrontendSettings struct {
 	PassHostHeader bool
 	// Should Stream?
 	Stream bool
+	// How frequently should we flush the stream?
+	StreamFlushIntervalSeconds uint64
 }
 
 func NewAddress(network, address string) (*Address, error) {

--- a/engine/model.go
+++ b/engine/model.go
@@ -230,7 +230,7 @@ type HTTPFrontendSettings struct {
 	// Should Stream?
 	Stream bool
 	// How frequently should we flush the stream?
-	StreamFlushIntervalSeconds uint64
+	StreamFlushIntervalNanoSecs uint64
 }
 
 func NewAddress(network, address string) (*Address, error) {

--- a/proxy/frontend.go
+++ b/proxy/frontend.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vulcand/oxy/roundrobin"
 	"github.com/vulcand/oxy/stream"
 	"github.com/vulcand/vulcand/engine"
+	"time"
 )
 
 type frontend struct {
@@ -115,6 +116,7 @@ func (f *frontend) rebuild() error {
 			}),
 		forward.PassHostHeader(settings.PassHostHeader),
 		forward.Stream(settings.Stream),
+		forward.StreamingFlushInterval(time.Duration(settings.StreamFlushIntervalSeconds) * time.Second),
 		forward.StateListener(f.mux.outgoingConnTracker))
 
 	// rtwatcher will be observing and aggregating metrics

--- a/proxy/frontend.go
+++ b/proxy/frontend.go
@@ -116,7 +116,7 @@ func (f *frontend) rebuild() error {
 			}),
 		forward.PassHostHeader(settings.PassHostHeader),
 		forward.Stream(settings.Stream),
-		forward.StreamingFlushInterval(time.Duration(settings.StreamFlushIntervalNanoSecs) * time.Nanosecond),
+		forward.StreamingFlushInterval(time.Duration(settings.StreamFlushIntervalNanoSecs)*time.Nanosecond),
 		forward.StateListener(f.mux.outgoingConnTracker))
 
 	// rtwatcher will be observing and aggregating metrics

--- a/proxy/frontend.go
+++ b/proxy/frontend.go
@@ -116,7 +116,7 @@ func (f *frontend) rebuild() error {
 			}),
 		forward.PassHostHeader(settings.PassHostHeader),
 		forward.Stream(settings.Stream),
-		forward.StreamingFlushInterval(time.Duration(settings.StreamFlushIntervalSeconds) * time.Second),
+		forward.StreamingFlushInterval(time.Duration(settings.StreamFlushIntervalNanoSecs) * time.Nanosecond),
 		forward.StateListener(f.mux.outgoingConnTracker))
 
 	// rtwatcher will be observing and aggregating metrics


### PR DESCRIPTION
This change is to ensure Frontend settings allow specifying of different flush intervals when streaming (chunked encoding) is used.

This allows us to configure different frontends with different flush settings.