### PR TITLE
Avoid HTML escaping in the json marshaling

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 
 	"github.com/vulcand/vulcand/engine"
 	"github.com/vulcand/vulcand/plugin"
+	"github.com/vulcand/vulcand/utils/json"
 
 	log "github.com/Sirupsen/logrus"
 )

--- a/engine/etcdv2ng/etcd.go
+++ b/engine/etcdv2ng/etcd.go
@@ -5,7 +5,6 @@ package etcdv2ng
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -20,6 +19,7 @@ import (
 	"github.com/vulcand/vulcand/engine"
 	"github.com/vulcand/vulcand/plugin"
 	"github.com/vulcand/vulcand/secret"
+	"github.com/vulcand/vulcand/utils/json"
 	"golang.org/x/net/context"
 )
 

--- a/engine/etcdv3ng/etcd.go
+++ b/engine/etcdv3ng/etcd.go
@@ -3,7 +3,6 @@
 package etcdv3ng
 
 import (
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	"github.com/vulcand/vulcand/engine"
 	"github.com/vulcand/vulcand/plugin"
 	"github.com/vulcand/vulcand/secret"
+	"github.com/vulcand/vulcand/utils/json"
 	"golang.org/x/net/context"
 )
 

--- a/utils/json/json.go
+++ b/utils/json/json.go
@@ -1,0 +1,25 @@
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func Marshal(v interface{}) ([]byte, error) {
+	var (
+		buf = &bytes.Buffer{}
+		enc = json.NewEncoder(buf)
+	)
+
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func Unmarshal(data []byte, v interface{}) error {
+	return json.Unmarshal(data, v)
+}

--- a/utils/json/json_test.go
+++ b/utils/json/json_test.go
@@ -1,0 +1,31 @@
+package json
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestMarshal(t *testing.T) {
+	for _, tCase := range []struct {
+		in  interface{}
+		out []byte
+	}{
+		{map[string]string{}, []byte("{}")},
+		{map[string]string{"fiz": "f&z"}, []byte(`{"fiz":"f&z"}`)},
+		{"foo & bar", []byte(`"foo & bar"`)},
+	} {
+		out, err := Marshal(tCase.in)
+
+		if err != nil {
+			t.Errorf("Unexecpted error: %s", err.Error())
+		}
+
+		if !bytes.Equal(out, append(tCase.out, []byte("\n")...)) {
+			t.Errorf(
+				"Wrong result: [%+v] instead of [%+v]",
+				string(out),
+				string(tCase.out),
+			)
+		}
+	}
+}


### PR DESCRIPTION
Related to #225 

In order to avoid the escaping of the "problematic HTML characters", i wrapped the JSON marshalling in a local package.