### PR TITLE
Fix the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.7.1
-  - 1.8
+  - 1.7
 script:
   - go test -v -p 1 --race $(go list ./... | grep -v '/vendor/')

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.6.3
   - 1.7.1
+  - 1.8
 script:
   - go test -v -p 1 --race $(go list ./... | grep -v '/vendor/')

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-onbuild
+FROM golang:1.7-onbuild
 EXPOSE 8181 8182
 RUN make install
 ENTRYPOINT ["/go/bin/vulcand"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5-onbuild
+FROM golang:1.8-onbuild
 EXPOSE 8181 8182
 RUN make install
 ENTRYPOINT ["/go/bin/vulcand"]


### PR DESCRIPTION
Move the testing vulcand against the Go version `1.7.1` and `1.8`.

Related to the comment https://github.com/vulcand/vulcand/pull/321#issuecomment-286887046