### PR TITLE
Add heap profiling capability

### DIFF
--- a/service/options.go
+++ b/service/options.go
@@ -3,10 +3,11 @@ package service
 import (
 	"flag"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
-	"github.com/mailgun/metrics"
 	"strings"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/mailgun/metrics"
 )
 
 type Options struct {
@@ -46,6 +47,8 @@ type Options struct {
 	MetricsClient metrics.Client
 
 	DefaultListener bool
+
+	MemProfileRate int
 }
 
 type SeverityFlag struct {
@@ -133,6 +136,8 @@ func ParseCommandLine() (options Options, err error) {
 	flag.StringVar(&options.StatsdAddr, "statsdAddr", "", "Statsd address in form of 'host:port'")
 
 	flag.BoolVar(&options.DefaultListener, "default-listener", true, "Enables the default listener on startup (Default value: true)")
+
+	flag.IntVar(&options.MemProfileRate, "memProfileRate", 0, "Heap profile rate in bytes (disabled if 0)")
 
 	flag.Parse()
 	options, err = validateOptions(options)

--- a/service/service.go
+++ b/service/service.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -70,6 +71,10 @@ func Run(registry *plugin.Registry) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse command line: %s", err)
 	}
+	if options.MemProfileRate > 0 {
+		runtime.MemProfileRate = options.MemProfileRate
+	}
+
 	service := NewService(options, registry)
 	if err := service.Start(waitForSignals()); err != nil {
 		log.Errorf("Failed to start service: %v", err)


### PR DESCRIPTION
With this changes you can enable memory profiling by passing `memProfileRate` parameter on the command line (e.g. `--memProfileRate=512`), that sets respective runtime [variable](https://golang.org/pkg/runtime/#pkg-variables). Then you can retrieve a heap profile at any time like that:
```
go tool pprof <path-to-vulcand-binary> http://<hostname>:8182/v2/pprof/heap
```

It may come handy to debug memory leaks and memory usage in general.