### PR TITLE
Faster and more reliable proxy initialization

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/vulcand/vulcand",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v75",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],
@@ -15,6 +15,10 @@
 			"ImportPath": "github.com/Sirupsen/logrus/hooks/syslog",
 			"Comment": "v0.11.0-25-g881bee4",
 			"Rev": "881bee4e20a5d11a6a88a5667c6f292072ac1963"
+		},
+		{
+			"ImportPath": "github.com/armon/go-proxyproto",
+			"Rev": "3daa90aec0039a806299b9078f4422fee950f33c"
 		},
 		{
 			"ImportPath": "github.com/beorn7/perks/quantile",
@@ -169,6 +173,11 @@
 			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",
 			"Comment": "v1.0.0-2-gc12348c",
 			"Rev": "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+		},
+		{
+			"ImportPath": "github.com/pkg/errors",
+			"Comment": "v0.8.0",
+			"Rev": "645ef00459ed84a119197bfb8d8205042c6df63d"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/prometheus",

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -37,7 +37,7 @@ func (s *ApiSuite) SetUpTest(c *C) {
 
 	s.ng = memng.New(registry.GetRegistry())
 
-	sv := supervisor.New(newProxy, s.ng, make(chan error), supervisor.Options{})
+	sv := supervisor.New(newProxy, s.ng, supervisor.Options{})
 
 	app, _ := scroll.NewApp()
 	InitProxyController(s.ng, sv, app)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -84,7 +84,7 @@ type Engine interface {
 	// It should be a blocking function generating events from change.go to the changes channel.
 	// Each change should be an instance of the struct provided in events.go
 	// In  case if cancel channel is closed, the subscribe events should no longer be generated.
-	Subscribe(events chan interface{}, afterIdx uint64, cancel chan bool) error
+	Subscribe(events chan interface{}, afterIdx uint64, cancel chan struct{}) error
 
 	// GetRegistry returns registry with the supported plugins. It should be stored by Engine instance.
 	GetRegistry() *plugin.Registry

--- a/engine/etcdv2ng/etcd.go
+++ b/engine/etcdv2ng/etcd.go
@@ -649,7 +649,7 @@ func (n *ng) backendUsedBy(bk engine.BackendKey) ([]engine.Frontend, error) {
 
 // Subscribe watches etcd changes and generates structured events telling vulcand to add or delete frontends, hosts etc.
 // It is a blocking function.
-func (n *ng) Subscribe(changes chan interface{}, afterIdx uint64, cancelC chan bool) error {
+func (n *ng) Subscribe(changes chan interface{}, afterIdx uint64, cancelC chan struct{}) error {
 	w := n.kapi.Watcher(n.etcdKey, &etcd.WatcherOptions{AfterIndex: afterIdx, Recursive: true})
 	for {
 		response, err := w.Next(n.context)

--- a/engine/etcdv2ng/etcd_test.go
+++ b/engine/etcdv2ng/etcd_test.go
@@ -27,7 +27,7 @@ type EtcdSuite struct {
 	context     context.Context
 	changesC    chan interface{}
 	key         string
-	stopC       chan bool
+	stopC       chan struct{}
 }
 
 var _ = Suite(&EtcdSuite{
@@ -88,7 +88,7 @@ func (s *EtcdSuite) SetUpTest(c *C) {
 	}
 
 	s.changesC = make(chan interface{})
-	s.stopC = make(chan bool)
+	s.stopC = make(chan struct{})
 	go s.ng.Subscribe(s.changesC, 0, s.stopC)
 
 	s.suite.ChangesC = s.changesC

--- a/engine/etcdv3ng/etcd.go
+++ b/engine/etcdv3ng/etcd.go
@@ -76,19 +76,19 @@ func (n *ng) GetSnapshot() (*engine.Snapshot, error) {
 	}
 	s := &engine.Snapshot{Index: uint64(response.Header.Revision)}
 
-	s.FrontendSpecs, err = n.parseFrontends(filterByPrefix(response.Kvs, n.etcdKey + "/frontends"))
+	s.FrontendSpecs, err = n.parseFrontends(filterByPrefix(response.Kvs, n.etcdKey+"/frontends"))
 	if err != nil {
 		return nil, err
 	}
-	s.BackendSpecs, err = n.parseBackends(filterByPrefix(response.Kvs, n.etcdKey + "/backends"))
+	s.BackendSpecs, err = n.parseBackends(filterByPrefix(response.Kvs, n.etcdKey+"/backends"))
 	if err != nil {
 		return nil, err
 	}
-	s.Hosts, err = n.parseHosts(filterByPrefix(response.Kvs, n.etcdKey + "/hosts"))
+	s.Hosts, err = n.parseHosts(filterByPrefix(response.Kvs, n.etcdKey+"/hosts"))
 	if err != nil {
 		return nil, err
 	}
-	s.Listeners, err = n.parseListeners(filterByPrefix(response.Kvs, n.etcdKey + "/listeners"))
+	s.Listeners, err = n.parseListeners(filterByPrefix(response.Kvs, n.etcdKey+"/listeners"))
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +597,7 @@ func (n *ng) backendUsedBy(bk engine.BackendKey) ([]engine.Frontend, error) {
 
 // Subscribe watches etcd changes and generates structured events telling vulcand to add or delete frontends, hosts etc.
 // It is a blocking function.
-func (n *ng) Subscribe(changes chan interface{}, afterIdx uint64, cancelC chan bool) error {
+func (n *ng) Subscribe(changes chan interface{}, afterIdx uint64, cancelC chan struct{}) error {
 	watcher := etcd.NewWatcher(n.client)
 	defer watcher.Close()
 

--- a/engine/etcdv3ng/etcd_test.go
+++ b/engine/etcdv3ng/etcd_test.go
@@ -26,7 +26,7 @@ type EtcdSuite struct {
 	context     context.Context
 	changesC    chan interface{}
 	key         string
-	stopC       chan bool
+	stopC       chan struct{}
 }
 
 var _ = Suite(&EtcdSuite{
@@ -87,7 +87,7 @@ func (s *EtcdSuite) SetUpTest(c *C) {
 	}
 
 	s.changesC = make(chan interface{})
-	s.stopC = make(chan bool)
+	s.stopC = make(chan struct{})
 
 	//find current index, so we only watch from now onwards
 	response, err := s.ng.client.Get(s.ng.context, "/")

--- a/engine/memng/mem.go
+++ b/engine/memng/mem.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 	"github.com/vulcand/vulcand/engine"
 	"github.com/vulcand/vulcand/plugin"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 // Mem is exported to provide easy access to its internals
@@ -52,8 +52,50 @@ func (m *Mem) emit(val interface{}) {
 func (m *Mem) Close() {
 }
 
-func (n *Mem) GetSnapshot() (*engine.Snapshot, error) {
-	return nil, &engine.SnapshotNotSupportedError{}
+func (m *Mem) GetSnapshot() (*engine.Snapshot, error) {
+	var ss engine.Snapshot
+	var err error
+
+	if ss.Hosts, err = m.GetHosts(); err != nil {
+		return nil, errors.Wrap(err, "failed to get hosts")
+	}
+
+	if ss.Listeners, err = m.GetListeners(); err != nil {
+		return nil, errors.Wrap(err, "failed to get listeners")
+	}
+
+	backends, err := m.GetBackends()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get backends")
+	}
+	for _, be := range backends {
+		bes := engine.BackendSpec{Backend: be}
+		servers, err := m.GetServers(engine.BackendKey{Id: be.Id})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get servers of %v", be.Id)
+		}
+		for _, svr := range servers {
+			bes.Servers = append(bes.Servers, svr)
+		}
+		ss.BackendSpecs = append(ss.BackendSpecs, bes)
+	}
+
+	frontends, err := m.GetFrontends()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get frontends")
+	}
+	for _, fe := range frontends {
+		fes := engine.FrontendSpec{Frontend: fe}
+		middlewares, err := m.GetMiddlewares(engine.FrontendKey{Id: fe.Id})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get middlewares of %v", fe.Id)
+		}
+		for _, mw := range middlewares {
+			fes.Middlewares = append(fes.Middlewares, mw)
+		}
+		ss.FrontendSpecs = append(ss.FrontendSpecs, fes)
+	}
+	return &ss, nil
 }
 
 func (m *Mem) GetLogSeverity() log.Level {

--- a/engine/memng/mem.go
+++ b/engine/memng/mem.go
@@ -362,7 +362,7 @@ func (m *Mem) DeleteServer(sk engine.ServerKey) error {
 	return &engine.NotFoundError{}
 }
 
-func (m *Mem) Subscribe(changes chan interface{}, afterIdx uint64, cancelC chan bool) error {
+func (m *Mem) Subscribe(changes chan interface{}, afterIdx uint64, cancelC chan struct{}) error {
 	for {
 		select {
 		case <-cancelC:

--- a/engine/memng/mem_test.go
+++ b/engine/memng/mem_test.go
@@ -13,7 +13,7 @@ func TestMem(t *testing.T) { TestingT(t) }
 
 type MemSuite struct {
 	suite test.EngineSuite
-	stopC chan bool
+	stopC chan struct{}
 }
 
 var _ = Suite(&MemSuite{})
@@ -22,7 +22,7 @@ func (s *MemSuite) SetUpTest(c *C) {
 	engine := New(registry.GetRegistry())
 
 	s.suite.ChangesC = make(chan interface{})
-	s.stopC = make(chan bool)
+	s.stopC = make(chan struct{})
 	go engine.Subscribe(s.suite.ChangesC, 0, s.stopC)
 	s.suite.Engine = engine
 }

--- a/engine/model.go
+++ b/engine/model.go
@@ -637,14 +637,6 @@ func (n *AlreadyExistsError) Error() string {
 	return n.Message
 }
 
-type SnapshotNotSupportedError struct {
-	Message string
-}
-
-func (e *SnapshotNotSupportedError) Error() string {
-	return e.Message
-}
-
 type Counters struct {
 	Period      time.Duration
 	NetErrors   int64

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -18,6 +18,8 @@ import (
 type Proxy interface {
 	engine.StatsProvider
 
+	Init(snapshot engine.Snapshot) error
+
 	UpsertHost(engine.Host) error
 	DeleteHost(engine.HostKey) error
 

--- a/proxy/stats.go
+++ b/proxy/stats.go
@@ -52,7 +52,6 @@ func (m *mux) emitMetrics() error {
 }
 
 func (m *mux) FrontendStats(key engine.FrontendKey) (*engine.RoundTripStats, error) {
-	log.Infof("%s FrontendStats", m)
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -64,7 +63,6 @@ func (m *mux) FrontendStats(key engine.FrontendKey) (*engine.RoundTripStats, err
 }
 
 func (m *mux) BackendStats(key engine.BackendKey) (*engine.RoundTripStats, error) {
-	log.Infof("%s BackendStats", m)
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -84,7 +82,6 @@ func (m *mux) BackendStats(key engine.BackendKey) (*engine.RoundTripStats, error
 }
 
 func (m *mux) ServerStats(key engine.ServerKey) (*engine.RoundTripStats, error) {
-	log.Infof("%s ServerStats", m)
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -120,7 +117,6 @@ func (m *mux) ServerStats(key engine.ServerKey) (*engine.RoundTripStats, error) 
 // TopFrontends returns locations sorted by criteria (faulty, slow, most used)
 // if hostname or backendId is present, will filter out locations for that host or backendId
 func (m *mux) TopFrontends(key *engine.BackendKey) ([]engine.Frontend, error) {
-	log.Infof("%s TopFrontends", m)
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
@@ -144,7 +140,6 @@ func (m *mux) TopFrontends(key *engine.BackendKey) ([]engine.Frontend, error) {
 // TopServers returns endpoints sorted by criteria (faulty, slow, mos used)
 // if backendId is not empty, will filter out endpoints for that backendId
 func (m *mux) TopServers(key *engine.BackendKey) ([]engine.Server, error) {
-	log.Infof("%s TopServers", m)
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 

--- a/service/service.go
+++ b/service/service.go
@@ -167,8 +167,7 @@ func (s *Service) Start(controlC chan ControlCode) error {
 	}
 
 	s.stapler = stapler.New()
-	s.supervisor = supervisor.New(
-		s.newProxy, s.ng, s.errorC, supervisor.Options{Files: muxFiles})
+	s.supervisor = supervisor.New(s.newProxy, s.ng, supervisor.Options{Files: muxFiles})
 
 	// Tells configurator to perform initial proxy configuration and start watching changes
 	if err := s.supervisor.Start(); err != nil {
@@ -208,12 +207,12 @@ func (s *Service) Start(controlC chan ControlCode) error {
 			switch controlCode {
 			case ControlCodeGracefulShutdown:
 				log.Info("Got graceful shutdown control code")
-				s.supervisor.Stop(true)
+				s.supervisor.Stop()
 				log.Infof("All servers stopped")
 				return nil
 			case ControlCodeImmediateShutdown:
 				log.Info("Got immediate shutdown control code")
-				s.supervisor.Stop(true)
+				s.supervisor.Stop()
 				return nil
 			case ControlCodeForkChild:
 				log.Infof("Got fork child control code")

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	retryPeriod       = 5 * time.Second
-	changesBufferSize = 0
+	changesBufferSize = 2000
 )
 
 // Supervisor watches changes to the dynamic backends and applies those changes

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -58,16 +58,16 @@ func (s *SupervisorSuite) TestInitFromExistingConfig(c *C) {
 	defer e.Close()
 
 	b := MakeBatch(Batch{Addr: "localhost:11800", Route: `Path("/")`, URL: e.URL})
-
 	c.Assert(s.ng.UpsertBackend(b.B), IsNil)
 	c.Assert(s.ng.UpsertServer(b.BK, b.S, engine.NoTTL), IsNil)
 	c.Assert(s.ng.UpsertFrontend(b.F, engine.NoTTL), IsNil)
 	c.Assert(s.ng.UpsertListener(b.L), IsNil)
 
+	// When
 	c.Assert(s.sv.Start(), IsNil)
 
+	// Then
 	time.Sleep(10 * time.Millisecond)
-
 	c.Assert(GETResponse(c, b.FrontendURL("/")), Equals, "Hi, I'm endpoint")
 }
 
@@ -77,15 +77,15 @@ func (s *SupervisorSuite) TestInitOnTheFly(c *C) {
 
 	s.sv.Start()
 
+	// When
 	b := MakeBatch(Batch{Addr: "localhost:11800", Route: `Path("/")`, URL: e.URL})
-
 	c.Assert(s.ng.UpsertBackend(b.B), IsNil)
 	c.Assert(s.ng.UpsertServer(b.BK, b.S, engine.NoTTL), IsNil)
 	c.Assert(s.ng.UpsertFrontend(b.F, engine.NoTTL), IsNil)
 	c.Assert(s.ng.UpsertListener(b.L), IsNil)
 
+	// Then
 	time.Sleep(10 * time.Millisecond)
-
 	c.Assert(GETResponse(c, b.FrontendURL("/")), Equals, "Hi, I'm endpoint")
 }
 
@@ -113,7 +113,6 @@ func (s *SupervisorSuite) TestRestartOnBackendErrors(c *C) {
 	defer e.Close()
 
 	b := MakeBatch(Batch{Addr: "localhost:11800", Route: `Path("/")`, URL: e.URL})
-
 	c.Assert(s.ng.UpsertBackend(b.B), IsNil)
 	c.Assert(s.ng.UpsertServer(b.BK, b.S, engine.NoTTL), IsNil)
 	c.Assert(s.ng.UpsertFrontend(b.F, engine.NoTTL), IsNil)
@@ -135,7 +134,6 @@ func (s *SupervisorSuite) TestTransferFiles(c *C) {
 	defer e.Close()
 
 	b := MakeBatch(Batch{Addr: "localhost:11800", Route: `Path("/")`, URL: e.URL})
-
 	c.Assert(s.ng.UpsertBackend(b.B), IsNil)
 	c.Assert(s.ng.UpsertServer(b.BK, b.S, engine.NoTTL), IsNil)
 	c.Assert(s.ng.UpsertFrontend(b.F, engine.NoTTL), IsNil)

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -24,33 +24,24 @@ func newProxy(id int) (proxy.Proxy, error) {
 }
 
 type SupervisorSuite struct {
-	clock  *timetools.FreezedTime
-	errorC chan error
-	sv     *Supervisor
-	ng     *memng.Mem
+	clock *timetools.FreezedTime
+	ng    *memng.Mem
 }
 
 func (s *SupervisorSuite) SetUpTest(c *C) {
 	s.ng = memng.New(registry.GetRegistry()).(*memng.Mem)
-
-	s.errorC = make(chan error)
-
 	s.clock = &timetools.FreezedTime{
 		CurrentTime: time.Date(2012, 3, 4, 5, 6, 7, 0, time.UTC),
 	}
-
-	s.sv = New(newProxy, s.ng, s.errorC, Options{Clock: s.clock})
-}
-
-func (s *SupervisorSuite) TearDownTest(c *C) {
-	s.sv.Stop(true)
 }
 
 var _ = Suite(&SupervisorSuite{})
 
 func (s *SupervisorSuite) TestStartStopEmpty(c *C) {
-	s.sv.Start()
-	fmt.Println("Stop")
+	sup := New(newProxy, s.ng, Options{Clock: s.clock})
+	err := sup.Start()
+	c.Assert(err, IsNil)
+	defer sup.Stop()
 }
 
 func (s *SupervisorSuite) TestInitFromExistingConfig(c *C) {
@@ -63,8 +54,11 @@ func (s *SupervisorSuite) TestInitFromExistingConfig(c *C) {
 	c.Assert(s.ng.UpsertFrontend(b.F, engine.NoTTL), IsNil)
 	c.Assert(s.ng.UpsertListener(b.L), IsNil)
 
+	sup := New(newProxy, s.ng, Options{Clock: s.clock})
+
 	// When
-	c.Assert(s.sv.Start(), IsNil)
+	c.Assert(sup.Start(), IsNil)
+	defer sup.Stop()
 
 	// Then
 	time.Sleep(10 * time.Millisecond)
@@ -75,7 +69,10 @@ func (s *SupervisorSuite) TestInitOnTheFly(c *C) {
 	e := testutils.NewResponder("Hi, I'm endpoint")
 	defer e.Close()
 
-	s.sv.Start()
+	sup := New(newProxy, s.ng, Options{Clock: s.clock})
+	err := sup.Start()
+	c.Assert(err, IsNil)
+	defer sup.Stop()
 
 	// When
 	b := MakeBatch(Batch{Addr: "localhost:11800", Route: `Path("/")`, URL: e.URL})
@@ -93,14 +90,16 @@ func (s *SupervisorSuite) TestGracefulShutdown(c *C) {
 	e := testutils.NewResponder("Hi, I'm endpoint")
 	defer e.Close()
 
-	s.sv.Start()
-
 	b := MakeBatch(Batch{Addr: "localhost:11800", Route: `Path("/")`, URL: e.URL})
-
 	c.Assert(s.ng.UpsertBackend(b.B), IsNil)
 	c.Assert(s.ng.UpsertServer(b.BK, b.S, engine.NoTTL), IsNil)
 	c.Assert(s.ng.UpsertFrontend(b.F, engine.NoTTL), IsNil)
 	c.Assert(s.ng.UpsertListener(b.L), IsNil)
+
+	sup := New(newProxy, s.ng, Options{Clock: s.clock})
+	err := sup.Start()
+	c.Assert(err, IsNil)
+	defer sup.Stop()
 
 	time.Sleep(10 * time.Millisecond)
 
@@ -118,7 +117,10 @@ func (s *SupervisorSuite) TestRestartOnBackendErrors(c *C) {
 	c.Assert(s.ng.UpsertFrontend(b.F, engine.NoTTL), IsNil)
 	c.Assert(s.ng.UpsertListener(b.L), IsNil)
 
-	s.sv.Start()
+	sup := New(newProxy, s.ng, Options{Clock: s.clock})
+	err := sup.Start()
+	c.Assert(err, IsNil)
+	defer sup.Stop()
 
 	time.Sleep(10 * time.Millisecond)
 
@@ -139,20 +141,23 @@ func (s *SupervisorSuite) TestTransferFiles(c *C) {
 	c.Assert(s.ng.UpsertFrontend(b.F, engine.NoTTL), IsNil)
 	c.Assert(s.ng.UpsertListener(b.L), IsNil)
 
-	s.sv.Start()
+	sup := New(newProxy, s.ng, Options{Clock: s.clock})
+	err := sup.Start()
+	c.Assert(err, IsNil)
 
 	time.Sleep(10 * time.Millisecond)
 
 	c.Assert(GETResponse(c, b.FrontendURL("/")), Equals, "Hi, I'm endpoint")
 
-	files, err := s.sv.GetFiles()
+	files, err := sup.GetFiles()
 	c.Assert(err, IsNil)
 
-	errorC := make(chan error)
+	sup2 := New(newProxy, s.ng, Options{Clock: s.clock, Files: files})
+	err = sup2.Start()
+	c.Assert(err, IsNil)
+	defer sup2.Stop()
 
-	sv2 := New(newProxy, s.ng, errorC, Options{Clock: s.clock, Files: files})
-	sv2.Start()
-	s.sv.Stop(true)
+	sup.Stop()
 
 	time.Sleep(10 * time.Millisecond)
 

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -7,11 +7,10 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 
-	"golang.org/x/crypto/ocsp"
-
 	routelib "github.com/vulcand/route"
 	"github.com/vulcand/vulcand/engine"
 	"github.com/vulcand/vulcand/plugin/ratelimit"
+	"golang.org/x/crypto/ocsp"
 )
 
 func init() {
@@ -65,33 +64,53 @@ func (b BatchVal) FrontendURL(path string) string {
 	return MakeURL(b.L, path)
 }
 
-func MakeBatch(b Batch) BatchVal {
+func MakeBatch(b Batch) (bv BatchVal) {
 	if b.Host == "" {
 		b.Host = "localhost"
 	}
-	if b.Protocol == "" {
-		b.Protocol = engine.HTTP
+	be := MakeBackend()
+	beSrv := MakeServer(b.URL)
+
+	bv.H = MakeHost(b.Host, b.KeyPair)
+	if b.Addr != "" {
+		if b.Protocol == "" {
+			b.Protocol = engine.HTTP
+		}
+		bv.L = MakeListener(b.Addr, b.Protocol)
+		bv.LK = engine.ListenerKey{Id: bv.L.Id}
 	}
-	h := MakeHost(b.Host, b.KeyPair)
-	bk := MakeBackend()
-	l := MakeListener(b.Addr, b.Protocol)
-	f := MakeFrontend(b.Route, bk.Id)
-	s := MakeServer(b.URL)
-	return BatchVal{
-		H: h,
+	bv.F = MakeFrontend(b.Route, be.Id)
+	bv.FK = engine.FrontendKey{Id: bv.F.Id}
+	bv.B = be
+	bv.BK = engine.BackendKey{Id: be.Id}
+	bv.S = beSrv
+	bv.SK = engine.ServerKey{BackendKey: engine.BackendKey{Id: be.Id}, Id: beSrv.Id}
+	return bv
+}
 
-		L:  l,
-		LK: engine.ListenerKey{Id: l.Id},
-
-		F:  f,
-		FK: engine.FrontendKey{Id: f.Id},
-
-		B:  bk,
-		BK: engine.BackendKey{Id: bk.Id},
-
-		S:  s,
-		SK: engine.ServerKey{BackendKey: engine.BackendKey{Id: bk.Id}, Id: s.Id},
+func (bv *BatchVal) Snapshot() engine.Snapshot {
+	return engine.Snapshot{
+		Hosts:     []engine.Host{bv.H},
+		Listeners: []engine.Listener{bv.L},
+		BackendSpecs: []engine.BackendSpec{
+			{Backend: bv.B, Servers: []engine.Server{bv.S}},
+		},
+		FrontendSpecs: []engine.FrontendSpec{
+			{Frontend: bv.F},
+		},
 	}
+}
+
+func MakeSnapshot(bvs ...BatchVal) engine.Snapshot {
+	var ss engine.Snapshot
+	for _, bv := range bvs {
+		bss := bv.Snapshot()
+		ss.Hosts = append(ss.Hosts, bss.Hosts...)
+		ss.BackendSpecs = append(ss.BackendSpecs, bss.BackendSpecs...)
+		ss.Listeners = append(ss.Listeners, bss.Listeners...)
+		ss.FrontendSpecs = append(ss.FrontendSpecs, bss.FrontendSpecs...)
+	}
+	return ss
 }
 
 func MakeHost(name string, keyPair *engine.KeyPair) engine.Host {
@@ -102,7 +121,7 @@ func MakeHost(name string, keyPair *engine.KeyPair) engine.Host {
 }
 
 func MakeListener(addr string, protocol string) engine.Listener {
-	l, err := engine.NewListener(UID("listener"), protocol, engine.TCP, addr, "", "", nil)
+	l, err := engine.NewListener(fmt.Sprintf("listener_%v", addr), protocol, engine.TCP, addr, "", "", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/vctl/command/command_test.go
+++ b/vctl/command/command_test.go
@@ -32,7 +32,7 @@ type CmdSuite struct {
 	out        *bytes.Buffer
 	cmd        *Command
 	testServer *httptest.Server
-	sv         *supervisor.Supervisor
+	sup        *supervisor.Supervisor
 }
 
 var _ = Suite(&CmdSuite{})
@@ -44,9 +44,9 @@ func (s *CmdSuite) SetUpTest(c *C) {
 		return proxy.New(id, stapler.New(), proxy.Options{})
 	}
 
-	sv := supervisor.New(newProxy, s.ng, make(chan error), supervisor.Options{})
+	sv := supervisor.New(newProxy, s.ng, supervisor.Options{})
 	sv.Start()
-	s.sv = sv
+	s.sup = sv
 
 	app, _ := scroll.NewApp()
 	api.InitProxyController(s.ng, sv, app)
@@ -57,7 +57,7 @@ func (s *CmdSuite) SetUpTest(c *C) {
 }
 
 func (s *CmdSuite) TearDownTest(c *C) {
-	s.sv.Stop(true)
+	s.sup.Stop()
 }
 
 func (s *CmdSuite) runString(in string) string {

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.3
+  - 1.5.4
+  - 1.6.2
+  - 1.7.1
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,269 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// and the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required the errors.WithStack and errors.WithMessage
+// functions destructure errors.Wrap into its component operations of annotating
+// an error with a stack trace and an a message, respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,178 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}


### PR DESCRIPTION
### Problem
Occasionally vulcand's memory consumption starts growing indefinitely until it is restarted by monitoring. According to the logs at that time Etcd update watcher in supervisor gets *401: The event in requested index is outdated and cleared (the requested history has been cleared [287132662/287131846]) [287133661]* error and tries to create a new multiplexer, but multiplexer initialization takes so much time that as soon as it is created the same Etcd error triggers another multiplexer reinitialization, and this process continues indefinitely.

### Solution
The solution is a complex of measures:
1. Multiplexer initialization logic was rewritten to be faster. Instead of calling general purpose `Proxy.UpsertXXX` methods single call to `Proxy.Init(ss engine.Snapshot)` is made. It only acquires the internal lock once and can leverage knowledge that it is initialization;
2. All of the multiplexer goroutines are now started in... surprise surprise `mux.Start()` function. Previously a couple of them were started in New before Init, in particular the one that started listening on Staples updates and reacting on them;
3. Supervisor starts listening for updates as soon as it gets the snapshot rather then after proxy initialization is over. Etcd does not allow us to control the maximum backlog of updates, but this change allows us to buffer updates effectively increasing the maximum possible update backlog to 1000 + \<internal buffer size\>.
 