### PR TITLE
Lazy frontend initialization

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/vulcand/vulcand/stapler"
 	"github.com/vulcand/vulcand/supervisor"
 	"github.com/vulcand/vulcand/testutils"
-
 	. "gopkg.in/check.v1"
 )
 

--- a/proxy/backend_test.go
+++ b/proxy/backend_test.go
@@ -1,0 +1,191 @@
+package proxy
+
+import (
+	"time"
+
+	"github.com/vulcand/vulcand/engine"
+	. "gopkg.in/check.v1"
+)
+
+var _ = Suite(&BackendSuite{})
+
+type BackendSuite struct {
+}
+
+func (s *BackendSuite) TestNew(c *C) {
+	beCfg, err := engine.NewHTTPBackend("foo", engine.HTTPBackendSettings{})
+	c.Assert(err, IsNil)
+	be, err := newBackend(*beCfg, Options{}, nil)
+	c.Assert(err, IsNil)
+
+	// When
+	_, srvCfgs := be.snapshot()
+
+	// Then
+	c.Assert(srvCfgs, IsNil)
+}
+
+func (s *BackendSuite) TestNewFailure(c *C) {
+	// When
+	beCfg, err := engine.NewHTTPBackend("foo", engine.HTTPBackendSettings{
+		Timeouts: engine.HTTPBackendTimeouts{
+			Dial: "bar",
+		},
+	})
+
+	// Then
+	c.Assert(err.Error(), Equals, "invalid dial timeout: time: invalid duration bar")
+	c.Assert(beCfg, IsNil)
+}
+
+// Returned server config is immutable, in the sense that it is not affected
+// by changes made to the backend after the snapshot that produced it was taken.
+func (s *BackendSuite) TestCopyOnRead(c *C) {
+	beCfg, err := engine.NewHTTPBackend("foo", engine.HTTPBackendSettings{})
+	c.Assert(err, IsNil)
+	be, err := newBackend(*beCfg, Options{}, []engine.Server{{Id: "1"}, {Id: "3"}})
+	c.Assert(err, IsNil)
+
+	// When
+	be.upsertServer(engine.Server{Id: "2"})
+	_, srvCfgs1 := be.snapshot()
+
+	be.upsertServer(engine.Server{Id: "3"}) // Duplicate
+	be.upsertServer(engine.Server{Id: "4"})
+	_, srvCfgs2 := be.snapshot()
+
+	be.deleteServer(engine.ServerKey{Id: "5"}) // Missing
+	be.deleteServer(engine.ServerKey{Id: "1"})
+	be.upsertServer(engine.Server{Id: "5"})
+	be.deleteServer(engine.ServerKey{Id: "2"})
+	be.upsertServer(engine.Server{Id: "1"})
+	_, srvCfgs3 := be.snapshot()
+
+	// Then
+	c.Assert(srvCfgs1, DeepEquals, []engine.Server{{Id: "1"}, {Id: "3"}, {Id: "2"}})
+	c.Assert(srvCfgs2, DeepEquals, []engine.Server{{Id: "1"}, {Id: "3"}, {Id: "2"}, {Id: "4"}})
+	c.Assert(srvCfgs3, DeepEquals, []engine.Server{{Id: "3"}, {Id: "4"}, {Id: "5"}, {Id: "1"}})
+}
+
+// Server Upsert/Delete functions report whether servers has actually been
+// updated.
+func (s *BackendSuite) TestServerUpdates(c *C) {
+	beCfg, err := engine.NewHTTPBackend("foo", engine.HTTPBackendSettings{})
+	c.Assert(err, IsNil)
+	be, err := newBackend(*beCfg, Options{}, []engine.Server{{Id: "1"}, {Id: "3"}})
+	c.Assert(err, IsNil)
+
+	// When/Then
+	c.Assert(be.upsertServer(engine.Server{Id: "2"}), Equals, true)
+	c.Assert(be.upsertServer(engine.Server{Id: "3"}), Equals, false)
+	c.Assert(be.upsertServer(engine.Server{Id: "4"}), Equals, true)
+	c.Assert(be.deleteServer(engine.ServerKey{Id: "5"}), Equals, false)
+	c.Assert(be.deleteServer(engine.ServerKey{Id: "1"}), Equals, true)
+	c.Assert(be.upsertServer(engine.Server{Id: "5"}), Equals, true)
+	c.Assert(be.deleteServer(engine.ServerKey{Id: "2"}), Equals, true)
+	c.Assert(be.upsertServer(engine.Server{Id: "1"}), Equals, true)
+	c.Assert(be.upsertServer(engine.Server{Id: "1"}), Equals, false)
+	c.Assert(be.upsertServer(engine.Server{Id: "3"}), Equals, false)
+	c.Assert(be.deleteServer(engine.ServerKey{Id: "5"}), Equals, true)
+
+	_, srvCfgs := be.snapshot()
+	c.Assert(srvCfgs, DeepEquals, []engine.Server{{Id: "3"}, {Id: "4"}, {Id: "1"}})
+}
+
+func (s *BackendSuite) TestUpdate(c *C) {
+	beCfg, err := engine.NewHTTPBackend("foo", engine.HTTPBackendSettings{
+		Timeouts: engine.HTTPBackendTimeouts{
+			Read:         "3s",
+			TLSHandshake: "15s",
+		},
+	})
+	c.Assert(err, IsNil)
+	be, err := newBackend(*beCfg, Options{}, []engine.Server{{Id: "1"}, {Id: "3"}})
+	c.Assert(err, IsNil)
+
+	beCfg2 := engine.Backend{
+		Id: "foo",
+		Settings: engine.HTTPBackendSettings{
+			Timeouts: engine.HTTPBackendTimeouts{
+				Read:         "7s",
+				TLSHandshake: "19s",
+			},
+		},
+	}
+
+	// When
+	mutated, err := be.update(beCfg2, Options{})
+
+	// Then
+	c.Assert(err, Equals, nil)
+	c.Assert(mutated, Equals, true)
+	tp, _ := be.snapshot()
+	c.Assert(tp.ResponseHeaderTimeout, Equals, 7*time.Second)
+	c.Assert(tp.TLSHandshakeTimeout, Equals, 19*time.Second)
+}
+
+// If the new config is essentially the same then Update returns mutated=false.
+func (s *BackendSuite) TestUpdateSame(c *C) {
+	beCfg, err := engine.NewHTTPBackend("foo", engine.HTTPBackendSettings{
+		Timeouts: engine.HTTPBackendTimeouts{
+			Read:         "3s",
+			TLSHandshake: "15s",
+		},
+	})
+	c.Assert(err, IsNil)
+	be, err := newBackend(*beCfg, Options{}, []engine.Server{{Id: "1"}, {Id: "3"}})
+	c.Assert(err, IsNil)
+
+	beCfg2 := engine.Backend{
+		Id: "foo",
+		Settings: engine.HTTPBackendSettings{
+			Timeouts: engine.HTTPBackendTimeouts{
+				Read:         "3s",
+				TLSHandshake: "15s",
+			},
+		},
+	}
+
+	// When
+	mutated, err := be.update(beCfg2, Options{})
+
+	// Then
+	c.Assert(err, Equals, nil)
+	c.Assert(mutated, Equals, false)
+	tp, _ := be.snapshot()
+	c.Assert(tp.ResponseHeaderTimeout, Equals, 3*time.Second)
+	c.Assert(tp.TLSHandshakeTimeout, Equals, 15*time.Second)
+}
+
+// Bad config is ignored entirely and does not result in partial update.
+func (s *BackendSuite) TestUpdateBadConfig(c *C) {
+	beCfg, err := engine.NewHTTPBackend("foo", engine.HTTPBackendSettings{
+		Timeouts: engine.HTTPBackendTimeouts{
+			Read:         "3s",
+			TLSHandshake: "15s",
+		},
+	})
+	c.Assert(err, IsNil)
+	be, err := newBackend(*beCfg, Options{}, []engine.Server{{Id: "1"}, {Id: "3"}})
+	c.Assert(err, IsNil)
+
+	beCfg2 := engine.Backend{
+		Id: "foo",
+		Settings: engine.HTTPBackendSettings{
+			Timeouts: engine.HTTPBackendTimeouts{
+				Read:         "5s",
+				TLSHandshake: "bar",
+			},
+		},
+	}
+
+	// When
+	mutated, err := be.update(beCfg2, Options{})
+
+	// Then
+	c.Assert(err.Error(), Equals, "bad config: invalid HTTP cfg: invalid tls handshake timeout: time: invalid duration bar")
+	c.Assert(mutated, Equals, false)
+	tp, _ := be.snapshot()
+	c.Assert(tp.ResponseHeaderTimeout, Equals, 3*time.Second)
+	c.Assert(tp.TLSHandshakeTimeout, Equals, 15*time.Second)
+}

--- a/proxy/conntrack.go
+++ b/proxy/conntrack.go
@@ -1,10 +1,11 @@
 package proxy
 
 import (
-	"github.com/vulcand/vulcand/conntracker"
 	"net"
 	"net/http"
 	"sync"
+
+	"github.com/vulcand/vulcand/conntracker"
 )
 
 type connTracker struct {

--- a/proxy/mux_test.go
+++ b/proxy/mux_test.go
@@ -100,7 +100,7 @@ func (s *ServerSuite) TestServerUpsertSame(c *C) {
 	c.Assert(GETResponse(c, b.FrontendURL("/")), Equals, "Hi, I'm endpoint")
 
 	c.Assert(s.mux.UpsertServer(b.BK, b.S), IsNil)
-	c.Assert(len(s.mux.backends[b.BK].servers), Equals, 1)
+	c.Assert(len(s.mux.backends[b.BK].backend.srvCfgs), Equals, 1)
 
 	c.Assert(GETResponse(c, b.FrontendURL("/")), Equals, "Hi, I'm endpoint")
 }

--- a/proxy/reporter.go
+++ b/proxy/reporter.go
@@ -6,16 +6,15 @@ import (
 	"net/url"
 	"sync"
 
+	"github.com/mailgun/timetools"
 	"github.com/vulcand/oxy/memmetrics"
 	"github.com/vulcand/oxy/utils"
 	"github.com/vulcand/vulcand/engine"
-
-	"github.com/mailgun/timetools"
 )
 
 // RTWatcher watches and aggregates runtime metrics
 type RTWatcher struct {
-	mtx   *sync.Mutex
+	mtx   sync.Mutex
 	m     *memmetrics.RTMetrics
 	srvs  map[surl]*memmetrics.RTMetrics
 	clock timetools.TimeProvider
@@ -29,7 +28,6 @@ func NewWatcher(next http.Handler) (*RTWatcher, error) {
 	}
 
 	return &RTWatcher{
-		mtx:   &sync.Mutex{},
 		m:     m,
 		clock: &timetools.RealTime{},
 		next:  next,

--- a/proxy/srv.go
+++ b/proxy/srv.go
@@ -2,19 +2,16 @@ package proxy
 
 import (
 	"crypto/tls"
-
 	"fmt"
 	"net"
 	"net/http"
-
-	"golang.org/x/crypto/ocsp"
-
-	"github.com/vulcand/vulcand/engine"
 
 	log "github.com/Sirupsen/logrus"
 	proxyproto "github.com/armon/go-proxyproto"
 	"github.com/mailgun/manners"
 	"github.com/vulcand/route"
+	"github.com/vulcand/vulcand/engine"
+	"golang.org/x/crypto/ocsp"
 )
 
 // srv contains all that is necessary to run the HTTP(s) server. server does not work on its own,

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -163,7 +163,7 @@ func (s *Supervisor) init() error {
 	// therefore does not handle updates.
 	cancelWatcher := true
 	changesC := make(chan interface{}, changesBufferSize)
-	s.watcherErrorC = make(chan struct{})
+	s.watcherErrorC = make(chan struct{}, 1)
 	s.watcherCancelC = make(chan struct{})
 	s.watcherWg.Add(1)
 	go func() {
@@ -261,6 +261,7 @@ func (s *Supervisor) run() {
 			s.watcherErrorC = nil
 		case <-s.stopC:
 			close(s.watcherCancelC)
+			s.engine.Close()
 			s.watcherWg.Wait()
 			if s.proxy != nil {
 				s.proxy.Stop(true)

--- a/vctl/command/command_test.go
+++ b/vctl/command/command_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/vulcand/vulcand/stapler"
 	"github.com/vulcand/vulcand/supervisor"
 	"github.com/vulcand/vulcand/testutils"
-
 	. "gopkg.in/check.v1"
 )
 


### PR DESCRIPTION
### Problem
In a large system with hundreds of frontends and even more backend servers, where vulcand is installed on many hosts that share the same etcd backend, vulcand instances tend to grow very large in size. One of the reasons is that even though only a subset of frontends is used by each particular instance, all of them are initialized with pretty heavy data structures.
### Solution
The frontend data structures has to be initialized on demand when a particular frontend is used for the first time. In our case this solution helped to reduce memory consumption by 15-35% depending on how many frontends were actually used by an instance.
### Implementation details
The proxy package was heavily redesigned to achieve this goal the majority of changes were made in `mux.go`, `backend.go`, `frontend.go`. The most prominent changes are:
1. Cyclic dependency `backend<->frontend` and `mux<->frontend` were broken to `frontend->backend` and `mux->frontend` respectively. Which is much easier to grasp;
2. Finer grain mutexes were introduced in backends and frontends to ensure that lazy initialization of frontends that happens in HTTP handlers now has consistent view on the mux matrix state;
3. Lots of renamings, I just could not figure out when the code was talking about proxy/backend and when about engine/backend;

As a bonus a regression introduced in PR327 that caused vulcand deadlock on stop was fixed.  

 