### PR TITLE
Add trustForwardHeader command line parameter

### DIFF
--- a/engine/model.go
+++ b/engine/model.go
@@ -204,6 +204,10 @@ func (h *Host) GetId() string {
 	return h.Name
 }
 
+func (h *Host) Key() HostKey {
+	return HostKey{Name: h.Name}
+}
+
 // Frontend is connected to a backend and vulcand will use the servers from this backend.
 type Frontend struct {
 	Id        string
@@ -336,7 +340,7 @@ func (l *Frontend) GetId() string {
 	return l.Id
 }
 
-func (l *Frontend) GetKey() FrontendKey {
+func (l *Frontend) Key() FrontendKey {
 	return FrontendKey{Id: l.Id}
 }
 
@@ -463,7 +467,7 @@ func (b *Backend) GetId() string {
 	return b.Id
 }
 
-func (b *Backend) GetUniqueId() BackendKey {
+func (b *Backend) Key() BackendKey {
 	return BackendKey{Id: b.Id}
 }
 

--- a/proxy/mux.go
+++ b/proxy/mux.go
@@ -171,7 +171,7 @@ func (m *mux) Init(ss engine.Snapshot) error {
 		for _, mw := range fes.Middlewares {
 			mwCfgs[engine.MiddlewareKey{FrontendKey: feKey, Id: mw.Id}] = mw
 		}
-		fe := newFrontend(fes.Frontend, beEnt.backend, mwCfgs, m.outgoingConnTracker)
+		fe := newFrontend(fes.Frontend, beEnt.backend, m.options, mwCfgs, m.outgoingConnTracker)
 		if err := m.router.Handle(fes.Frontend.Route, fe); err != nil {
 			return errors.Wrapf(err, "cannot add route %v for frontend %v",
 				fes.Frontend.Route, fes.Frontend.Id)
@@ -495,7 +495,7 @@ func (m *mux) UpsertFrontend(feCfg engine.Frontend) error {
 		}
 		return nil
 	}
-	fe = newFrontend(feCfg, beEnt.backend, nil, m.outgoingConnTracker)
+	fe = newFrontend(feCfg, beEnt.backend, m.options, nil, m.outgoingConnTracker)
 	m.frontends[feKey] = fe
 	beEnt.frontends[feKey] = fe
 	if err := m.router.Handle(feCfg.Route, fe); err != nil {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -58,6 +58,7 @@ type Options struct {
 	WriteTimeout              time.Duration
 	MaxHeaderBytes            int
 	DefaultListener           *engine.Listener
+	TrustForwardHeader        bool
 	Files                     []*FileDescriptor
 	TimeProvider              timetools.TimeProvider
 	NotFoundMiddleware        plugin.Middleware

--- a/service/options.go
+++ b/service/options.go
@@ -46,7 +46,8 @@ type Options struct {
 	StatsdPrefix  string
 	MetricsClient metrics.Client
 
-	DefaultListener bool
+	DefaultListener    bool
+	TrustForwardHeader bool
 
 	MemProfileRate int
 }
@@ -136,6 +137,7 @@ func ParseCommandLine() (options Options, err error) {
 	flag.StringVar(&options.StatsdAddr, "statsdAddr", "", "Statsd address in form of 'host:port'")
 
 	flag.BoolVar(&options.DefaultListener, "default-listener", true, "Enables the default listener on startup (Default value: true)")
+	flag.BoolVar(&options.TrustForwardHeader, "trustForwardHeader", false, "Whether X-Forwarded-XXX headers should be trusted")
 
 	flag.IntVar(&options.MemProfileRate, "memProfileRate", 0, "Heap profile rate in bytes (disabled if 0)")
 

--- a/service/service.go
+++ b/service/service.go
@@ -408,6 +408,7 @@ func (s *Service) newProxy(id int) (proxy.Proxy, error) {
 		WriteTimeout:       s.options.ServerWriteTimeout,
 		MaxHeaderBytes:     s.options.ServerMaxHeaderBytes,
 		DefaultListener:    constructDefaultListener(s.options),
+		TrustForwardHeader: s.options.TrustForwardHeader,
 		NotFoundMiddleware: s.registry.GetNotFoundMiddleware(),
 		Router:             s.registry.GetRouter(),
 		IncomingConnectionTracker: s.registry.GetIncomingConnectionTracker(),


### PR DESCRIPTION
### Problem
Sometimes you need to run Vulcand behind another proxy. In that case `X-Forwarded-` headers should be trusted by Vulcand. Before this change, the headers could be made trusted by a per-frontend configuration knobe `TrustForwardHeader` set to `true`. But in most cases it would be easier to just enable that setting at the process level. Because usually you either run vulcand behind another proxy or not.

### Solution
Command line parameter `trustForwardHeader` was added. So that if either `trustForwardHeader` command line parameter or `TrustForwardHeader` frontend parameter is `true` then Vulcand leaves `X-Forwarded-Proto` and `X-Forwarded-Host` intact and augments `X-Forwarded-For` so that new value is constructed as `<old value>, <vulcand ip address>`.