### PR TITLE
An error re-writing the request body should continue

### DIFF
--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -109,8 +109,7 @@ func (rw *rewriteHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	rw.next.ServeHTTP(bw, req)
 
 	if err := Apply(bw.buffer, newBody, req); err != nil {
-		log.Errorf("Failed to rewrite response body: %v", err)
-		return
+		log.Errorf("While rewriting response body for '%s': %v", req.RequestURI, err)
 	}
 
 	utils.CopyHeaders(w.Header(), bw.Header())


### PR DESCRIPTION
## Purpose
Fixes an issue encountered where a response body contains `{{ }}` but is not a valid template. As written vulcand returns and error and exits without providing a body or status code.

## Implementation
* Improved error to include the URL the error occurred on
* Now returns the un-modified payload on error