### PR TITLE
Fix SNI Test to work with multiple hosts correctly

### DIFF
--- a/graceful/listener.go
+++ b/graceful/listener.go
@@ -54,6 +54,10 @@ func (l *Listener) Accept() (net.Conn, error) {
 		}
 		return nil, err
 	}
+	if tlsc, ok := conn.(*tls.Conn); ok {
+		err := tlsc.Handshake()
+		fmt.Printf("=============> HandShake error: %v. Handshake Complete: %v, ServerName: %s, CertSerial: %v\n\n", err, tlsc.ConnectionState().HandshakeComplete, tlsc.ConnectionState().ServerName, tls.ConnectionState().PeerCertificates[0].SerialNumber)
+	}
 	return conn, nil
 }
 

--- a/graceful/listener.go
+++ b/graceful/listener.go
@@ -54,10 +54,6 @@ func (l *Listener) Accept() (net.Conn, error) {
 		}
 		return nil, err
 	}
-	if tlsc, ok := conn.(*tls.Conn); ok {
-		err := tlsc.Handshake()
-		fmt.Printf("=============> HandShake error: %v. Handshake Complete: %v, ServerName: %s, CertSerial: %v\n\n", err, tlsc.ConnectionState().HandshakeComplete, tlsc.ConnectionState().ServerName, tls.ConnectionState().PeerCertificates[0].SerialNumber)
-	}
 	return conn, nil
 }
 

--- a/proxy/mux/mux_test.go
+++ b/proxy/mux/mux_test.go
@@ -472,6 +472,9 @@ func (s *ServerSuite) TestSNI(c *C) {
 	// When/Then
 	c.Assert(GETResponse(c, b.FrontendURL("/"), testutils.Host("localhost")), Equals, "Hi, I'm endpoint 1")
 	c.Assert(GETResponse(c, b.FrontendURL("/"), testutils.Host("otherhost")), Equals, "Hi, I'm endpoint 2")
+
+	c.Assert(GETPeerCertSerialNo(c, b.FrontendURL("/"), testutils.Host("localhost")), Equals, "7b0b0f8903e43e656b4e5a7ddc6c82e")
+	c.Assert(GETPeerCertSerialNo(c, b.FrontendURL("/"), testutils.Host("otherhost")), Equals, "077bdc3e97d00584f03faec7cda682cf")
 }
 
 func (s *ServerSuite) TestMiddlewareCRUD(c *C) {
@@ -1135,6 +1138,15 @@ func GETResponse(c *C, url string, opts ...testutils.ReqOption) string {
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 	return string(body)
 }
+
+func GETPeerCertSerialNo(c *C, url string, opts ...testutils.ReqOption) string {
+	response, _, err := testutils.Get(url, opts...)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+	c.Assert(response.TLS, NotNil)
+	return response.TLS.PeerCertificates[0].SerialNumber.Text(16)
+}
+
 
 // localhostCert is a PEM-encoded TLS cert with SAN IPs
 // "127.0.0.1" and "[::1]", expiring at the last second of 2049 (the end

--- a/vendor/github.com/vulcand/oxy/testutils/utils.go
+++ b/vendor/github.com/vulcand/oxy/testutils/utils.go
@@ -120,7 +120,10 @@ func MakeRequest(url string, opts ...ReqOption) (*http.Response, []byte, error) 
 	if strings.HasPrefix(url, "https") {
 		tr = &http.Transport{
 			DisableKeepAlives: true,
-			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig:   &tls.Config{
+				InsecureSkipVerify: true,
+				ServerName: request.Host, //Necessary for SNI to work
+			},
 		}
 	} else {
 		tr = &http.Transport{
@@ -134,6 +137,7 @@ func MakeRequest(url string, opts ...ReqOption) (*http.Response, []byte, error) 
 			return fmt.Errorf("No redirects")
 		},
 	}
+
 	response, err := client.Do(request)
 	if err == nil {
 		bodyBytes, err := ioutil.ReadAll(response.Body)


### PR DESCRIPTION
When testing AutoCert, I realized that this test was not comprehensive enough.

If we add an additional host call, say "foobar", we get a 404 back because the
route doesn't exist for it. However, the default cert is returned regardless.

This means that if we checked for the Certificate Serial Number on the returned
cert, it is constant across any host name. In short, exposing multiple SSL
Certs by Host, will not result in different certs being returned
based on the request made.

I have set up the initial conditions for the test which fails right now.

I'll figure out how to make it pass.