### PR TITLE
Added -localhost-alias option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 flymake_*
 *.swp
 *.go~
+.idea/

--- a/proxy/mux/mux_test.go
+++ b/proxy/mux/mux_test.go
@@ -161,6 +161,29 @@ func (s *ServerSuite) TestTwoHosts(c *C) {
 	c.Assert(GETResponse(c, b.FrontendURL("/"), testutils.Host("otherhost")), Equals, "Hi, I'm endpoint 2")
 }
 
+// Test case when user defined a localhost alias
+func (s *ServerSuite) TestLocalhostAlias(c *C) {
+	e := testutils.NewResponder("Hi, I'm endpoint 1")
+	defer e.Close()
+
+	mux, err := New(s.lastId, s.st, proxy.Options{LocalhostAlias: "alias"})
+	c.Assert(err, IsNil)
+	s.mux = mux
+
+	c.Assert(s.mux.Start(), IsNil)
+
+	b := MakeBatch(Batch{Addr: "localhost:41000", Route: `Host("localhost") && Path("/")`, URL: e.URL})
+
+	c.Assert(s.mux.UpsertServer(b.BK, b.S), IsNil)
+
+	c.Assert(s.mux.UpsertFrontend(b.F), IsNil)
+
+	c.Assert(s.mux.UpsertListener(b.L), IsNil)
+
+	c.Assert(GETResponse(c, b.FrontendURL("/"), testutils.Host("localhost")), Equals, "Hi, I'm endpoint 1")
+	c.Assert(GETResponse(c, b.FrontendURL("/"), testutils.Host("alias")), Equals, "Hi, I'm endpoint 1")
+}
+
 func (s *ServerSuite) TestListenerCRUD(c *C) {
 	e := testutils.NewResponder("Hi, I'm endpoint")
 	defer e.Close()

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -68,6 +68,7 @@ type Options struct {
 	IncomingConnectionTracker conntracker.ConnectionTracker
 	FrontendListeners         plugin.FrontendListeners
 	CacheProvider             cacheprovider.T
+	LocalhostAlias            string
 }
 
 type NewProxyFn func(id int) (Proxy, error)

--- a/service/options.go
+++ b/service/options.go
@@ -50,6 +50,7 @@ type Options struct {
 	TrustForwardHeader bool
 
 	MemProfileRate int
+	LocalhostAlias string
 }
 
 type SeverityFlag struct {
@@ -140,6 +141,7 @@ func ParseCommandLine() (options Options, err error) {
 	flag.BoolVar(&options.TrustForwardHeader, "trustForwardHeader", false, "Whether X-Forwarded-XXX headers should be trusted")
 
 	flag.IntVar(&options.MemProfileRate, "memProfileRate", 0, "Heap profile rate in bytes (disabled if 0)")
+	flag.StringVar(&options.LocalhostAlias, "localhost-alias", "", "Frontend rules that match Host('localhost') will also match this alias")
 
 	flag.Parse()
 	options, err = validateOptions(options)

--- a/service/service.go
+++ b/service/service.go
@@ -425,6 +425,7 @@ func (s *Service) newProxy(id int) (proxy.Proxy, error) {
 		IncomingConnectionTracker: s.registry.GetIncomingConnectionTracker(),
 		FrontendListeners:         s.registry.GetFrontendListeners(),
 		CacheProvider:             cacheProvider,
+		LocalhostAlias:            s.options.LocalhostAlias,
 	})
 }
 


### PR DESCRIPTION
## Purpose
When running vulcand in a kubernetes `DaemonSet` vulcand needs to know requests from the local node should match `Host("localhost")` rules. This flag allows an author of a vulcand `DaemonSet` to tell vulcand the name of the node it's currently running on, such that vulcand correctly routes requests for `Host("localhost")` 

## Implementation
* Simple search and replace for `Route` rules and add additional route handler with the alias host.
