### PR TITLE
Improve startup performance by using router.InitHandlers()

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -191,7 +191,7 @@
   branch = "master"
   name = "github.com/vulcand/route"
   packages = ["."]
-  revision = "61904570391bdf22252f8e376b49a57593d9124c"
+  revision = "81ef6c58993f941040084f06336c46a0b684dffb"
 
 [[projects]]
   name = "golang.org/x/crypto"
@@ -308,6 +308,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e9c33d8e0c6a2c2167d235b08372a097e6cdf38174c531369afa7d57befbab1d"
+  inputs-digest = "354b9d63f2c1265f1681f7f5a9e0051a33ff71e0bc28b5be9e51517ae63dcf92"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,6 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
-
 [[constraint]]
   name = "github.com/armon/go-proxyproto"
   revision = "3daa90aec0039a806299b9078f4422fee950f33c"
@@ -68,6 +67,10 @@
 [[constraint]]
   branch = "v1"
   name = "gopkg.in/check.v1"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/vulcand/route"
 
 [prune]
   go-tests = true

--- a/router/router.go
+++ b/router/router.go
@@ -18,6 +18,9 @@ type Router interface {
 	// Adds a new route->handler combination. The route is a string which provides the routing expression. http.Handler is called when this expression matches a request.
 	Handle(string, http.Handler) error
 
+	// Adds a map of handlers and expressions in a single call.
+	InitHandlers(map[string]interface{}) error
+
 	// Removes a route. The http.Handler associated with it, will be discarded.
 	Remove(string) error
 

--- a/vendor/github.com/vulcand/route/mux.go
+++ b/vendor/github.com/vulcand/route/mux.go
@@ -20,6 +20,13 @@ func NewMux() *Mux {
 	}
 }
 
+// This adds a map of handlers and expressions in a single call. This allows
+// init to load many rules on first startup, thus reducing the time it takes to
+// create the initial mux.
+func (m *Mux) InitHandlers(handlers map[string]interface{}) error {
+	return m.router.InitRoutes(handlers)
+}
+
 // Handle adds http handler for route expression
 func (m *Mux) Handle(expr string, handler http.Handler) error {
 	return m.router.UpsertRoute(expr, handler)
@@ -71,4 +78,3 @@ func (notFound) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Not found")
 
 }
-

--- a/vendor/github.com/vulcand/route/router.go
+++ b/vendor/github.com/vulcand/route/router.go
@@ -67,6 +67,9 @@ type Router interface {
 	// UpsertRoute updates an existing route or adds a new route by given expression
 	UpsertRoute(string, interface{}) error
 
+	// Initializes the routes, this method clobbers all existing routes and should only be called during init
+	InitRoutes(map[string]interface{}) error
+
 	// Route takes a request and matches it against requests, returns matched route in case if found, nil if there's no matching route or error in case of internal error.
 	Route(*http.Request) (interface{}, error)
 }
@@ -93,6 +96,28 @@ func (e *router) GetRoute(expr string) interface{} {
 	if ok {
 		return res.val
 	}
+	return nil
+}
+
+func (e *router) InitRoutes(routes map[string]interface{}) error {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	for expr, val := range routes {
+		if _, ok := e.routes[expr]; ok {
+			return fmt.Errorf("expression '%s' already exists", expr)
+		}
+		result := &match{val: val}
+		if _, err := parse(expr, result); err != nil {
+			return err
+		}
+		e.routes[expr] = result
+	}
+
+	if err := e.compile(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -144,7 +169,7 @@ func (e *router) compile() error {
 	}
 	sort.Sort(sort.Reverse(sort.StringSlice(exprs)))
 
-	matchers := []matcher{}
+	var matchers []matcher
 	i := 0
 	for _, expr := range exprs {
 		result := e.routes[expr]


### PR DESCRIPTION
## Purpose
This change allows users to add many routes quickly during mux initialization. Currently, Vulcand takes just under 2 minutes to load 1,600 routes depending on the CPU and load. This change allows Vulcand to load the same number of routes in 200ms.

This PR Requires https://github.com/vulcand/route/pull/17 to be merged before tests will pass.