### PR TITLE
Respect etcdCaFile in absence of key/cert pair

### DIFF
--- a/engine/etcdng/tls.go
+++ b/engine/etcdng/tls.go
@@ -9,35 +9,30 @@ import (
 )
 
 func NewTLSConfig(opt Options) *tls.Config {
-	var cfg *tls.Config = nil
+	if opt.CertFile == "" && opt.KeyFile == "" && opt.CaFile == "" && !opt.EnableTLS && !opt.InsecureSkipVerify {
+		return nil
+	}
+
+	cfg := tls.Config{
+		InsecureSkipVerify: opt.InsecureSkipVerify,
+	}
+
+	if opt.CaFile != "" {
+		if pemBytes, err := ioutil.ReadFile(opt.CaFile); err == nil {
+			cfg.RootCAs = x509.NewCertPool()
+			cfg.RootCAs.AppendCertsFromPEM(pemBytes)
+		} else {
+			log.WithError(err).Errorf("Error reading etcd cert CA File")
+		}
+	}
 
 	if opt.CertFile != "" && opt.KeyFile != "" {
-		var rpool *x509.CertPool = nil
-		if opt.CaFile != "" {
-			if pemBytes, err := ioutil.ReadFile(opt.CaFile); err == nil {
-				rpool = x509.NewCertPool()
-				rpool.AppendCertsFromPEM(pemBytes)
-			} else {
-				log.WithError(err).Errorf("Error reading etcd cert CA File")
-			}
-		}
-
 		if tlsCert, err := tls.LoadX509KeyPair(opt.CertFile, opt.KeyFile); err == nil {
-			cfg = &tls.Config{
-				RootCAs:            rpool,
-				Certificates:       []tls.Certificate{tlsCert},
-				InsecureSkipVerify: opt.InsecureSkipVerify,
-			}
+			cfg.Certificates = []tls.Certificate{tlsCert}
 		} else {
 			log.WithError(err).Errorf("Error loading KeyPair for TLS client")
 		}
 	}
 
-	// If InsecureSkipVerify is provided, assume TLS
-	if (opt.EnableTLS || opt.InsecureSkipVerify) && cfg == nil {
-		cfg = &tls.Config{
-			InsecureSkipVerify: opt.InsecureSkipVerify,
-		}
-	}
-	return cfg
+	return &cfg
 }


### PR DESCRIPTION
Currently if Etcd key/cert pair is not present etcd CA file won't be taken into consideration and as a result connection to Etcd fails. This PR rectifies this by allowing to specify just `etcdCaFile` to establish a TLS connection with Etcd.