### PR TITLE
Allow user to pass comma separated list of etcd nodes

### DIFF
--- a/service/options.go
+++ b/service/options.go
@@ -87,7 +87,8 @@ func (o *listOptions) String() string {
 }
 
 func (o *listOptions) Set(value string) error {
-	*o = append(*o, value)
+	parts := strings.Split(value, ",")
+	*o = append(*o, parts...)
 	return nil
 }
 


### PR DESCRIPTION
## Purpose
Currently `-etcd` flag only allows the user to pass in a single etcd endpoint. This PR allows the user to optionally pass in additional endpoints separated by a comma 