### PR TITLE
Added timeout while establishing etcd v3 watch

### DIFF
--- a/engine/etcdng/v3/etcd.go
+++ b/engine/etcdng/v3/etcd.go
@@ -597,9 +597,19 @@ func (n *ng) Subscribe(changes chan interface{}, afterIdx uint64, cancelC chan s
 	watcher := etcd.NewWatcher(n.client)
 	defer watcher.Close()
 
-	log.Infof("begin watching: etcd revision %d", afterIdx)
-	watchChan := watcher.Watch(etcd.WithRequireLeader(n.context),
-		n.etcdKey, etcd.WithRev(int64(afterIdx)), etcd.WithPrefix())
+	var watchChan etcd.WatchChan
+	ready := make(chan struct{})
+	go func() {
+		watchChan = watcher.Watch(etcd.WithRequireLeader(n.context), n.etcdKey,
+			etcd.WithRev(int64(afterIdx)), etcd.WithPrefix())
+		close(ready)
+	}()
+	select {
+	case <-ready:
+		log.Infof("begin watching: etcd revision %d", afterIdx)
+	case <-time.After(time.Second * 10):
+		return errors.New("timed out while waiting for watcher.Watch() to start")
+	}
 
 	for response := range watchChan {
 		if response.Canceled {


### PR DESCRIPTION
## Purpose
While using the etcd v3 protocol watches can silently timeout or fail to establish a watch. 

* https://github.com/etcd-io/etcd/pull/10019 
* https://github.com/etcd-io/etcd/pull/10020

## Implementation
In the case etcd v3 `Watch()` blocks indefinitely vulcand should error and try again. As Vulcand already retries when `init()` returns an error.  `Subscribe()` now returns an error when `watcher.Watch()` takes to long to return.

Also added `WithRequireLeader()` to avoid etcd network splits from blocking watches indefinitely (See https://github.com/etcd-io/etcd/issues/7593#issuecomment-288930039) 