### PR TITLE
Test for supported Go versions

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -15,7 +15,7 @@ jobs:
     name: test
     strategy:
       matrix:
-        go-version: [ 1.18.x, 1.19.x ]
+        go-version: [ oldstable, stable ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 


### PR DESCRIPTION
Test for supported Go versions and utilizing the new “stable” and “oldstable” version aliases to avoid having to update this again for each successive Go version.